### PR TITLE
Codestyle workflow updated

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -3,23 +3,30 @@ name: codestyle
 on:
   pull_request:
     paths:
-      - '*.py'
+      - '**.py'
 
 jobs:
   autoblack:
-    runs-on: [ ubuntu-latest, windows-latest, macos-latest ]
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
   flake8_py3:
-    runs-on: [ ubuntu-latest, windows-latest, macos-latest ]
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        python-version: [ 3.5, 3.6, 3.7, 3.8, 3.9 ]
+    runs-on: ${{ matrix.os }}
     needs: [ autoblack ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -6,21 +6,12 @@ on:
       - '**.py'
 
 jobs:
-  autoblack:
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: psf/black@stable
   flake8_py3:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
         python-version: [ 3.5, 3.6, 3.7, 3.8, 3.9 ]
     runs-on: ${{ matrix.os }}
-    needs: [ autoblack ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Lint with flake8
         run: |
           pip install flake8
-          flake8 .
+          flake8 --ignore=E501,F841,E203,W503,W504 .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,10 +5,11 @@ on: [ pull_request ]
 jobs:
   build:
 
-    runs-on: [ ubuntu-latest, windows-latest, macos-latest ]
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9 ]
+        python-version: [ 3.5, 3.6, 3.7, 3.8, 3.9 ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
@@ -20,7 +21,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install -r requirements.txt
       - name: Test with pytest
         run: |
           pytest

--- a/README.md
+++ b/README.md
@@ -105,5 +105,4 @@ pipeline is executed on all PRs before review and contributors are expected to a
 ### A Continuous Integration (CI) pipeline does the following jobs:
 
 - Executes all unit tests from the pull request.
-- Uses the command line code formatting tool [black](https://github.com/psf/black) for validating Python code style.
 - Analyzes code style using Flake8.

--- a/peerdid/peer_did.py
+++ b/peerdid/peer_did.py
@@ -2,8 +2,14 @@ import json
 import re
 from typing import List, Optional
 
-from peerdid.peer_did_utils import _encode_service, _create_encnumbasis, \
-    _build_did_doc_numalgo_0, _build_did_doc_numalgo_2, _check_key_correctly_encoded, _is_json
+from peerdid.peer_did_utils import (
+    _encode_service,
+    _create_encnumbasis,
+    _build_did_doc_numalgo_0,
+    _build_did_doc_numalgo_2,
+    _check_key_correctly_encoded,
+    _is_json,
+)
 from peerdid.types import PEER_DID, PublicKeyAgreement, PublicKeyAuthentication, JSON
 
 
@@ -11,16 +17,15 @@ def is_peer_did(peer_did: PEER_DID) -> bool:
     """
     Checks if peer_did parameter matches Peer DID spec
     (https://identity.foundation/peer-did-method-spec/index.html#matching-regex)
-
     :param peer_did: peer_did to check
-
     :return: True if peer_did matches spec, otherwise False
     """
     if peer_did is None:
         return False
     peer_did_pattern = re.compile(
         r"^did:peer:(([0](z)([1-9a-km-zA-HJ-NP-Z]{46,47}))|(2((\.[AEVID](z)([1-9a-km-zA-HJ-NP-Z]{46,47}))+"
-        r"(\.(S)[0-9a-zA-Z=]*)?)))$")
+        r"(\.(S)[0-9a-zA-Z=]*)?)))$"
+    )
     return bool(re.match(peer_did_pattern, peer_did))
 
 
@@ -29,34 +34,38 @@ def create_peer_did_numalgo_0(inception_key: PublicKeyAuthentication) -> PEER_DI
     Generates peer_did according to the zero algorithm
     (https://identity.foundation/peer-did-method-spec/index.html#generation-method).
     For this type of algorithm did_doc can be obtained from peer_did
-
     :param inception_key: the key that creates the DID and authenticates when exchanging it with the first peer
-
     :raises TypeError: if the inception_key is not instance of PublicKeyAuthentication
     :raises ValueError: if the inception_key is not correctly encoded
-
     :return: generated peer_did
     """
     if not isinstance(inception_key, PublicKeyAuthentication):
-        raise TypeError(f"Wrong type of inception_key: {str(type(inception_key))}. Expected: PublicKeyAuthentication")
-    if not _check_key_correctly_encoded(inception_key.encoded_value, inception_key.encoding_type):
-        raise ValueError(f"Inception key is not correctly encoded")
-    peer_did = 'did:peer:0z' + _create_encnumbasis(inception_key)
+        raise TypeError(
+            "Wrong type of inception_key: "
+            + str(type(inception_key))
+            + ". Expected: PublicKeyAuthentication"
+        )
+    if not _check_key_correctly_encoded(
+        inception_key.encoded_value, inception_key.encoding_type
+    ):
+        raise ValueError("Inception key is not correctly encoded")
+    peer_did = "did:peer:0z" + _create_encnumbasis(inception_key)
     return peer_did
 
 
-def create_peer_did_numalgo_2(encryption_keys: List[PublicKeyAgreement], signing_keys: List[PublicKeyAuthentication],
-                              service: Optional[JSON]) -> PEER_DID:
+def create_peer_did_numalgo_2(
+    encryption_keys: List[PublicKeyAgreement],
+    signing_keys: List[PublicKeyAuthentication],
+    service: Optional[JSON],
+) -> PEER_DID:
     """
     Generates peer_did according to the second algorithm
     (https://identity.foundation/peer-did-method-spec/index.html#generation-method).
     For this type of algorithm did_doc can be obtained from peer_did
-
     :param encryption_keys: list of encryption keys
     :param signing_keys: list of signing keys
     :param service: JSON string conforming to the DID specification (https://www.w3.org/TR/did-core/#services)
         or None if there is no services expected for this DID
-
     :raises TypeError:
         1. if at least one of encryption keys is not instance of PublicKeyAgreement or
             at least one of signing keys is not instance of PublicKeyAuthentication
@@ -64,50 +73,64 @@ def create_peer_did_numalgo_2(encryption_keys: List[PublicKeyAgreement], signing
     :raises ValueError:
         1. if at least one of keys is not properly encoded
         2. if service is not valid JSON
-
     :return: generated peer_did
     """
     for key in encryption_keys:
         if not isinstance(key, PublicKeyAgreement):
-            raise TypeError(f'Wrong type of encryption_key {key}: {str(type(key))}')
+            raise TypeError(
+                "Wrong type of encryption_key "
+                + key.encoded_value
+                + " : "
+                + str(type(key))
+            )
         if not _check_key_correctly_encoded(key.encoded_value, key.encoding_type):
-            raise ValueError(f"Encryption key: {key} is not correctly encoded")
+            raise ValueError(
+                "Encryption key: " + key.encoded_value + " is not correctly encoded"
+            )
     for key in signing_keys:
         if not isinstance(key, PublicKeyAuthentication):
-            raise TypeError(f'Wrong type of signing_key {key}: {str(type(key))}')
+            raise TypeError(
+                "Wrong type of signing_key " + key.encoded_value + ": " + str(type(key))
+            )
         if not _check_key_correctly_encoded(key.encoded_value, key.encoding_type):
-            raise ValueError(f"Signing key: {key} is not correctly encoded")
+            raise ValueError(
+                "Signing key: " + key.encoded_value + " is not correctly encoded"
+            )
     try:
         if service is not None:
             _is_json(service)
     except TypeError as exte:
-        raise TypeError('Service is not JSON type') from exte
+        raise TypeError("Service is not JSON type") from exte
     except ValueError as exve:
-        raise ValueError('Service is not valid JSON') from exve
-    encryption_keys_str = '.Ez' + '.Ez'.join(
-        _create_encnumbasis(key) for key in encryption_keys) if encryption_keys else ''
-    signing_keys_str = '.Vz' + '.Vz'.join(_create_encnumbasis(key) for key in signing_keys) if signing_keys else ''
-    service_str = _encode_service(service) if service else ''
+        raise ValueError("Service is not valid JSON") from exve
+    encryption_keys_str = (
+        ".Ez" + ".Ez".join(_create_encnumbasis(key) for key in encryption_keys)
+        if encryption_keys
+        else ""
+    )
+    signing_keys_str = (
+        ".Vz" + ".Vz".join(_create_encnumbasis(key) for key in signing_keys)
+        if signing_keys
+        else ""
+    )
+    service_str = _encode_service(service) if service else ""
 
-    peer_did = 'did:peer:2' + encryption_keys_str + signing_keys_str + service_str
+    peer_did = "did:peer:2" + encryption_keys_str + signing_keys_str + service_str
     return peer_did
 
 
 def resolve_peer_did(peer_did: PEER_DID, version_id=None) -> JSON:
     """
     Resolves did_doc from peer_did
-
     :param peer_did: peer_did to resolve
     :param version_id: a specific version of a DID doc. If value is default, version of DID doc will be latest.
         version_id is not used for now, as we support only static layer where did doc never changes
-
     :raises ValueError: if peer_did parameter does not match peer_did spec
-
     :return: resolved did_doc as a JSON string
     """
     if not is_peer_did(peer_did):
-        raise ValueError('Invalid Peer DID')
-    if peer_did[9] == '0':
+        raise ValueError("Invalid Peer DID")
+    if peer_did[9] == "0":
         return json.dumps(_build_did_doc_numalgo_0(peer_did=peer_did), indent=4)
-    if peer_did[9] == '2':
+    if peer_did[9] == "2":
         return json.dumps(_build_did_doc_numalgo_2(peer_did=peer_did), indent=4)

--- a/peerdid/peer_did_utils.py
+++ b/peerdid/peer_did_utils.py
@@ -1,14 +1,21 @@
 import base64
 import hashlib
-import json
 import re
+import json
 from typing import Union, List
 
 import base58
 import varint
 
-from peerdid.types import JSON, PublicKeyAgreement, PublicKeyAuthentication, PublicKeyTypeAgreement, \
-    PublicKeyTypeAuthentication, PEER_DID, EncodingType
+from peerdid.types import (
+    JSON,
+    PublicKeyAgreement,
+    PublicKeyAuthentication,
+    PublicKeyTypeAgreement,
+    PublicKeyTypeAuthentication,
+    PEER_DID,
+    EncodingType,
+)
 
 
 def _encode_service(service: JSON) -> str:
@@ -16,46 +23,44 @@ def _encode_service(service: JSON) -> str:
     Generates encoded service according to the second algorithm
     (https://identity.foundation/peer-did-method-spec/index.html#generation-method)
     For this type of algorithm did_doc can be obtained from peer_did
-
     :param service: JSON string conforming to the DID specification (https://www.w3.org/TR/did-core/#services)
-
     :return: encoded service
     """
-    service_to_encode = re.sub(r"[\n\t\s]*", "", service) \
-        .replace('\'', '\"') \
-        .replace("type", "t") \
-        .replace("serviceEndpoint", "s") \
-        .replace("didcommmessaging", 'dm') \
-        .replace("routingKeys", 'r') \
-        .encode('ascii')
-    return '.S' + base64.b64encode(service_to_encode).decode("utf-8")
+    service_to_encode = (
+        re.sub(r"[\n\t\s]*", "", service)
+        .replace("'", '"')
+        .replace("type", "t")
+        .replace("serviceEndpoint", "s")
+        .replace("didcommmessaging", "dm")
+        .replace("routingKeys", "r")
+        .encode("ascii")
+    )
+    return ".S" + base64.b64encode(service_to_encode).decode("utf-8")
 
 
 def _decode_service(service: str, peer_did: PEER_DID) -> List[dict]:
     """
     Decodes service according to Peer DID spec
     (https://identity.foundation/peer-did-method-spec/index.html#example-2-abnf-for-peer-dids)
-
     :param service: service to decode
     :param peer_did: peer_did which will be used as an ID
-
     :raises ValueError: if peer_did parameter is not valid
-
     :return: decoded service
     """
     from peerdid.peer_did import is_peer_did
+
     if not is_peer_did(peer_did):
-        raise ValueError('Invalid peer_did')
+        raise ValueError("Invalid peer_did")
     decoded_service = base64.b64decode(service)
-    list_of_service_dict = json.loads(decoded_service)
+    list_of_service_dict = json.loads(decoded_service.decode("utf-8"))
     if not isinstance(list_of_service_dict, list):
         list_of_service_dict = [list_of_service_dict]
     for service in list_of_service_dict:
-        service_type = service.pop('t').replace("dm", 'didcommmessaging')
-        service['id'] = peer_did + f'#{service_type}'
-        service['type'] = service_type
-        service['serviceEndpoint'] = service.pop('s')
-        service['routingKeys'] = service.pop('r')
+        service_type = service.pop("t").replace("dm", "didcommmessaging")
+        service["id"] = peer_did + "#" + service_type
+        service["type"] = service_type
+        service["serviceEndpoint"] = service.pop("s")
+        service["routingKeys"] = service.pop("r")
     return list_of_service_dict
 
 
@@ -63,54 +68,50 @@ def _create_encnumbasis(key: Union[PublicKeyAgreement, PublicKeyAuthentication])
     """
     Creates encnumbasis according to Peer DID spec
     (https://identity.foundation/peer-did-method-spec/index.html#method-specific-identifier)
-
     :param key: public key
-
     :return: encnumbasis
     """
     decoded_key = base58.b58decode(key.encoded_value)
     prefixed_decoded_key = _add_prefix(key.type, decoded_key)
     encnumbasis = base58.b58encode(prefixed_decoded_key)
-    return encnumbasis.decode('utf-8')
+    return encnumbasis.decode("utf-8")
 
 
 def _decode_encnumbasis(encnumbasis: str, peer_did: PEER_DID) -> dict:
     """
     Decodes encnumbasis
-
     :param encnumbasis: encnumbasis to decode
     :param peer_did: peer_did which will be used as an ID
-
     :return: decoded encnumbasis
     """
     decoded_encnumbasis = base58.b58decode(encnumbasis)
     codec = _get_codec(data=bytes(decoded_encnumbasis))
     decoded_encnumbasis_without_prefix = _remove_prefix(decoded_encnumbasis)
-    public_key = base58.b58encode(decoded_encnumbasis_without_prefix).decode('utf-8')
-    return {'id': peer_did + '#' + encnumbasis, 'type': codec, 'controller': peer_did, 'publicKeyBase58': public_key}
+    public_key = base58.b58encode(decoded_encnumbasis_without_prefix).decode("utf-8")
+    return {
+        "id": peer_did + "#" + encnumbasis,
+        "type": codec,
+        "controller": peer_did,
+        "publicKeyBase58": public_key,
+    }
 
 
 def _remove_prefix(data: bytes) -> bytes:
     """
     Removes prefix from data
-
     :param data: prefixed data
-
     :return: data without prefix
     """
     prefix_int = _extract_prefix(data)
     prefix = varint.encode(prefix_int)
-    return data[len(prefix):]
+    return data[len(prefix) :]
 
 
 def _get_codec(data: bytes) -> str:
     """
     Gets codec from data
-
     :param data: prefixed data
-
     :raises ValueError: if prefix is not supported
-
     :return: codec name
     """
     prefix = _extract_prefix(data)
@@ -119,44 +120,39 @@ def _get_codec(data: bytes) -> str:
     elif prefix in set(item.value for item in PublicKeyTypeAgreement):
         return PublicKeyTypeAgreement(prefix).name
     else:
-        raise ValueError('Prefix {} not present in the lookup table'.format(prefix))
+        raise ValueError("Prefix {} not present in the lookup table".format(prefix))
 
 
 def _extract_prefix(data: bytes) -> int:
     """
     Extracts prefix from data
-
     :param data: prefixed data
-
     :raises ValueError: if invalid varint provided
-
     :return: prefix
     """
     try:
         return varint.decode_bytes(data)
     except TypeError:
-        raise ValueError('incorrect varint provided')
+        raise ValueError("incorrect varint provided")
 
 
-def _add_prefix(key_type: Union[PublicKeyTypeAgreement, PublicKeyTypeAuthentication], data: bytes) -> bytes:
+def _add_prefix(
+    key_type: Union[PublicKeyTypeAgreement, PublicKeyTypeAuthentication], data: bytes
+) -> bytes:
     """
     Adds prefix to a data
-
     :param key_type: type of key
     :param data: data to be prefixed
-
     :return: prefixed data
     """
     prefix = varint.encode(key_type.value)
-    return b''.join([prefix, data])
+    return b"".join([prefix, data])
 
 
 def _encode_filename(filename: str) -> str:
     """
     Encodes filename to SHA256 string
-
     :param filename: name of file
-
     :return: encoded filename as SHA256 string
     """
     return hashlib.sha256(filename.encode()).hexdigest()
@@ -165,66 +161,66 @@ def _encode_filename(filename: str) -> str:
 def _build_did_doc_numalgo_0(peer_did: PEER_DID) -> dict:
     """
     Helper method to create did_doc according to numalgo 0
-
     :param peer_did: peer_did to resolve
-
     :raises ValueError:
         1) if peer_did contains encryption key instead of signing
         2) if peer_did contains unsupported transform part
-
     :return: did_doc
     """
     inception_key = peer_did[11:]
     encoding_algorithm = peer_did[10]
-    if not encoding_algorithm == 'z':
-        raise ValueError(f'Unsupported encoding algorithm of key: {encoding_algorithm}')
+    if not encoding_algorithm == "z":
+        raise ValueError("Unsupported encoding algorithm of key: " + encoding_algorithm)
     decoded_encnumbasis = _decode_encnumbasis(inception_key, peer_did)
-    if not decoded_encnumbasis['type'] in PublicKeyTypeAuthentication.__members__:
-        raise ValueError('Invalid key type (encryption instead of signing)')
-    did_doc = {
-        'id': peer_did,
-        'authentication': decoded_encnumbasis
-    }
+    if not decoded_encnumbasis["type"] in PublicKeyTypeAuthentication.__members__:
+        raise ValueError("Invalid key type (encryption instead of signing)")
+    did_doc = {"id": peer_did, "authentication": decoded_encnumbasis}
     return did_doc
 
 
 def _build_did_doc_numalgo_2(peer_did: PEER_DID) -> dict:
     """
     Helper method to create did_doc according to numalgo 2
-
     :param peer_did: peer_did to resolve
-
     :return: did_doc
     """
     keys = peer_did[11:]
-    keys = keys.split('.')
-    service = ''
+    keys = keys.split(".")
+    service = ""
     keys_without_purpose_code = []
     for key in keys:
-        if key[0] != 'S':
+        if key[0] != "S":
             transform = key[1]
-            if not transform == 'z':
-                raise ValueError(f'Unsupported transform part of peer_did: {transform}')
+            if not transform == "z":
+                raise ValueError("Unsupported transform part of peer_did: " + transform)
             keys_without_purpose_code.append(key[2:])
         else:
             service = key[1:]
-    decoded_encnumbasises = [_decode_encnumbasis(key, peer_did) for key in keys_without_purpose_code]
+    decoded_encnumbasises = [
+        _decode_encnumbasis(key, peer_did) for key in keys_without_purpose_code
+    ]
     decoded_service = _decode_service(service, peer_did)
 
     authentication = []
     key_agreement = []
     for i in range(len(decoded_encnumbasises)):
-        if decoded_encnumbasises[i]['type'] in PublicKeyTypeAuthentication.__members__ and keys[i][0] == 'V':
+        if (
+            decoded_encnumbasises[i]["type"] in PublicKeyTypeAuthentication.__members__
+            and keys[i][0] == "V"
+        ):
             authentication.append(decoded_encnumbasises[i])
-        elif decoded_encnumbasises[i]['type'] in PublicKeyTypeAgreement.__members__ and keys[i][0] == 'E':
+        elif (
+            decoded_encnumbasises[i]["type"] in PublicKeyTypeAgreement.__members__
+            and keys[i][0] == "E"
+        ):
             key_agreement.append(decoded_encnumbasises[i])
         else:
-            raise ValueError(f'Invalid key type of: {keys[i]}')
+            raise ValueError("Invalid key type of: " + keys[i])
     did_doc = {
-        'id': peer_did,
-        'authentication': authentication,
-        'keyAgreement': key_agreement,
-        'service': decoded_service
+        "id": peer_did,
+        "authentication": authentication,
+        "keyAgreement": key_agreement,
+        "service": decoded_service,
     }
     return did_doc
 
@@ -232,15 +228,13 @@ def _build_did_doc_numalgo_2(peer_did: PEER_DID) -> dict:
 def _check_key_correctly_encoded(key: str, encoding_type: EncodingType) -> bool:
     """
     Checks if key correctly encoded
-
     :param key: any string
     :param encoding_type: encoding type
-
     :return: true if key correctly encoded, otherwise false
     """
     if not encoding_type == EncodingType.BASE58:
         return False
-    alphabet = set('123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz')
+    alphabet = set("123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz")
     byte_lengths = (32,)
     invalid_chars = set(key) - alphabet
     if invalid_chars:
@@ -254,11 +248,8 @@ def _check_key_correctly_encoded(key: str, encoding_type: EncodingType) -> bool:
 def _is_json(str_to_check: str) -> bool:
     """
     Checks if str is JSON
-
     :param str_to_check: sting to check
-
     :return: true if str is JSON, otherwise raises ValueError or TypeError
-
     :raises TypeError: if str_to_check is not str type
     :raises ValueError: if str_to_check is not valid JSON
     """

--- a/peerdid/storage.py
+++ b/peerdid/storage.py
@@ -20,20 +20,31 @@ class Storage(ABC):
 
 
 class FileStorage(Storage):
-    DEFAULT_PEERDID_FOLDER_PATH = str(Path.home() / '.peerdids')
-    DEFAULT_PEERDID_FILE_EXTENSION = '.diddoc'
+    DEFAULT_PEERDID_FOLDER_PATH = str(Path.home() / ".peerdids")
+    DEFAULT_PEERDID_FILE_EXTENSION = ".diddoc"
 
-    def __init__(self, peer_did_filename: str, peer_did_storage_folder: str = None,
-                 did_doc_file_extension: str = None):
-        self.peer_did_storage_folder = peer_did_storage_folder or self.DEFAULT_PEERDID_FOLDER_PATH
+    def __init__(
+        self,
+        peer_did_filename: str,
+        peer_did_storage_folder: str = None,
+        did_doc_file_extension: str = None,
+    ):
+        self.peer_did_storage_folder = (
+            peer_did_storage_folder or self.DEFAULT_PEERDID_FOLDER_PATH
+        )
         self.peer_did_filename = peer_did_filename
-        self.did_doc_file_extension = did_doc_file_extension or self.DEFAULT_PEERDID_FILE_EXTENSION
+        self.did_doc_file_extension = (
+            did_doc_file_extension or self.DEFAULT_PEERDID_FILE_EXTENSION
+        )
 
     def save(self, data: bytes):
         """
         Saves data to a storage
         """
-        file_path = os.path.join(self.peer_did_storage_folder, self.peer_did_filename + self.did_doc_file_extension)
+        file_path = os.path.join(
+            self.peer_did_storage_folder,
+            self.peer_did_filename + self.did_doc_file_extension,
+        )
         with open(file_path, "bw+") as f:
             f.write(data)
 
@@ -41,7 +52,10 @@ class FileStorage(Storage):
         """
         Loads data from a storage
         """
-        file_path = os.path.join(self.peer_did_storage_folder, self.peer_did_filename + self.did_doc_file_extension)
+        file_path = os.path.join(
+            self.peer_did_storage_folder,
+            self.peer_did_filename + self.did_doc_file_extension,
+        )
         with open(file_path, "rb") as f:
             data = f.read()
             return data

--- a/peerdid/types.py
+++ b/peerdid/types.py
@@ -1,33 +1,37 @@
-from dataclasses import dataclass
 from enum import Enum
+from typing import NamedTuple
 
 
 class PublicKeyTypeAgreement(Enum):
-    X25519 = 0xec
+    X25519 = 0xEC
 
 
 class PublicKeyTypeAuthentication(Enum):
-    ED25519 = 0xed
-    SECP256K1 = 0xe7
+    ED25519 = 0xED
+    SECP256K1 = 0xE7
 
 
 class EncodingType(Enum):
     BASE58 = 0
 
 
-@dataclass
-class PublicKeyAgreement:
-    encoding_type: EncodingType
-    encoded_value: str
-    type: PublicKeyTypeAgreement
+PublicKeyAgreement = NamedTuple(
+    "PublicKeyAgreement",
+    [
+        ("encoding_type", EncodingType),
+        ("encoded_value", str),
+        ("type", PublicKeyTypeAgreement),
+    ],
+)
 
-
-@dataclass
-class PublicKeyAuthentication:
-    encoding_type: EncodingType
-    encoded_value: str
-    type: PublicKeyTypeAuthentication
-
+PublicKeyAuthentication = NamedTuple(
+    "PublicKeyAuthentication",
+    [
+        ("encoding_type", EncodingType),
+        ("encoded_value", str),
+        ("type", PublicKeyTypeAuthentication),
+    ],
+)
 
 JSON = str
 PEER_DID = str

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pytest~=6.2.4
+pytest
 base58~=2.1.0
 varint~=1.0.2

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setup(
     ],
     packages=["peerdid"],
     install_requires=[],
-    test_requires=['pytest']
+    test_requires=["pytest"],
 )

--- a/tests/demo.py
+++ b/tests/demo.py
@@ -1,21 +1,35 @@
-from peerdid.peer_did import create_peer_did_numalgo_0, create_peer_did_numalgo_2, resolve_peer_did
-from peerdid.peer_did_utils import _encode_filename
+from peerdid.peer_did import (
+    create_peer_did_numalgo_0,
+    create_peer_did_numalgo_2,
+    resolve_peer_did,
+)
 from peerdid.storage import FileStorage
-from peerdid.types import PublicKeyAuthentication, PublicKeyAgreement, PublicKeyTypeAgreement, \
-    PublicKeyTypeAuthentication, EncodingType
+from peerdid.peer_did_utils import _encode_filename
+from peerdid.types import (
+    PublicKeyAuthentication,
+    PublicKeyAgreement,
+    PublicKeyTypeAgreement,
+    PublicKeyTypeAuthentication,
+    EncodingType,
+)
 
 
 def test_create_save_resolve_peer_did():
     encryption_keys = [
-        PublicKeyAgreement(type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58,
-                           encoded_value="DmgBSHMqaZiYqwNMEJJuxWzsGGC8jUYADrfSdBrC6L8s")
+        PublicKeyAgreement(
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+            encoded_value="DmgBSHMqaZiYqwNMEJJuxWzsGGC8jUYADrfSdBrC6L8s",
+        )
     ]
     signing_keys = [
-        PublicKeyAuthentication(type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58,
-                                encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7")
+        PublicKeyAuthentication(
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+            encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
+        )
     ]
-    service = \
-        '''
+    service = """
             [
                 {
                     "type": "didcommmessaging",
@@ -28,23 +42,23 @@ def test_create_save_resolve_peer_did():
                     "routingKeys": ["did:example:somemediator#somekey2"]
                 }
             ]
-        '''
+        """
 
     peer_did_algo_0 = create_peer_did_numalgo_0(inception_key=signing_keys[0])
-    peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys,
-                                                signing_keys=signing_keys,
-                                                service=service)
+    peer_did_algo_2 = create_peer_did_numalgo_2(
+        encryption_keys=encryption_keys, signing_keys=signing_keys, service=service
+    )
 
-    print('peer_did_algo_0:' + peer_did_algo_0)
-    print('==================================')
-    print('peer_did_algo_2:' + peer_did_algo_2)
-    print('==================================')
+    print("peer_did_algo_0:" + peer_did_algo_0)
+    print("==================================")
+    print("peer_did_algo_2:" + peer_did_algo_2)
+    print("==================================")
 
     file_storage = FileStorage(peer_did_filename=_encode_filename(peer_did_algo_2))
-    file_storage.save(bytes(peer_did_algo_2, encoding='utf-8'))
+    file_storage.save(bytes(peer_did_algo_2, encoding="utf-8"))
 
     did_doc_algo_0 = resolve_peer_did(peer_did=peer_did_algo_0)
     did_doc_algo_2 = resolve_peer_did(peer_did=peer_did_algo_2)
-    print('did_doc_algo_0:' + did_doc_algo_0)
-    print('==================================')
-    print('did_doc_algo_2:' + did_doc_algo_2)
+    print("did_doc_algo_0:" + did_doc_algo_0)
+    print("==================================")
+    print("did_doc_algo_2:" + did_doc_algo_2)

--- a/tests/test_create_peer_did_numalgo_0.py
+++ b/tests/test_create_peer_did_numalgo_0.py
@@ -1,60 +1,89 @@
 import pytest
 
 from peerdid.peer_did import create_peer_did_numalgo_0, is_peer_did
-from peerdid.types import PublicKeyAuthentication, PublicKeyTypeAuthentication, PublicKeyAgreement, \
-    PublicKeyTypeAgreement, EncodingType
+from peerdid.types import (
+    PublicKeyAuthentication,
+    PublicKeyTypeAuthentication,
+    PublicKeyAgreement,
+    PublicKeyTypeAgreement,
+    EncodingType,
+)
 
 
 def test_create_numalgo_0_positive():
-    signing_keys = [PublicKeyAuthentication(
-        encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
-        type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
+    signing_keys = [
+        PublicKeyAuthentication(
+            encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
 
     peer_did_algo_0 = create_peer_did_numalgo_0(inception_key=signing_keys[0])
-    assert peer_did_algo_0 == "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+    assert (
+        peer_did_algo_0 == "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+    )
     assert is_peer_did(peer_did_algo_0)
 
 
 def test_create_numalgo_0_malformed_inception_key_not_base58_encoded():
     inception_key = PublicKeyAuthentication(
         encoded_value="zx8xB2pv7cw8q1Pd0DacS",
-        type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)
+        type=PublicKeyTypeAuthentication.ED25519,
+        encoding_type=EncodingType.BASE58,
+    )
 
     with pytest.raises(ValueError):
         peer_did = create_peer_did_numalgo_0(inception_key=inception_key)
 
 
 def test_create_numalgo_0_malformed_short_inception_key():
-    signing_keys = [PublicKeyAuthentication(
-        encoded_value="ByHnp",
-        type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
+    signing_keys = [
+        PublicKeyAuthentication(
+            encoded_value="ByHnp",
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
 
     with pytest.raises(ValueError):
         peer_did_algo_0 = create_peer_did_numalgo_0(inception_key=signing_keys[0])
 
 
 def test_create_numalgo_0_malformed_long_inception_key():
-    signing_keys = [PublicKeyAuthentication(
-        encoded_value="ByHnpUCFb1vAfh9CFZ8ByHnpUCFbZkmUZguURW8HnpUCFbZkmUnByHnpUCFbSHnpUCFbZkmUw889hByHnpUCFby6rD8L7",
-        type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
+    signing_keys = [
+        PublicKeyAuthentication(
+            encoded_value="ByHnpUCFb1vAfh9CFZ8ByHnpUCFbZkmUZguURW8HnpUCFbZkmUnByHnpUCFbSHnpUCFbZkmUw889hByHnpUCFby6rD8L7",
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
 
     with pytest.raises(ValueError):
         peer_did_algo_0 = create_peer_did_numalgo_0(inception_key=signing_keys[0])
 
 
 def test_create_numalgo_0_malformed_empty_inception_key():
-    signing_keys = [PublicKeyAuthentication(
-        encoded_value="",
-        type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
+    signing_keys = [
+        PublicKeyAuthentication(
+            encoded_value="",
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
 
     with pytest.raises(ValueError):
         peer_did_algo_0 = create_peer_did_numalgo_0(inception_key=signing_keys[0])
 
 
 def test_create_numalgo_0_invalid_inception_key_type():
-    signing_keys = [PublicKeyAgreement(
-        encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
-        type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58)]
+    signing_keys = [
+        PublicKeyAgreement(
+            encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
 
     with pytest.raises(TypeError):
         peer_did_algo_0 = create_peer_did_numalgo_0(inception_key=signing_keys[0])

--- a/tests/test_create_peer_did_numalgo_2.py
+++ b/tests/test_create_peer_did_numalgo_2.py
@@ -1,21 +1,36 @@
 import pytest
 
 from peerdid.peer_did import create_peer_did_numalgo_2, is_peer_did
-from peerdid.types import PublicKeyAgreement, PublicKeyTypeAgreement, PublicKeyAuthentication, \
-    PublicKeyTypeAuthentication, EncodingType
+from peerdid.types import (
+    PublicKeyAgreement,
+    PublicKeyTypeAgreement,
+    PublicKeyAuthentication,
+    PublicKeyTypeAuthentication,
+    EncodingType,
+)
 
 
 def test_create_numalgo_2_positive():
-    encryption_keys = [PublicKeyAgreement(encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
-                                          type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58)]
+    encryption_keys = [
+        PublicKeyAgreement(
+            encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
     signing_keys = [
         PublicKeyAuthentication(
             encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58),
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
         PublicKeyAuthentication(
             encoded_value="3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
-    service = '''[
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
+    ]
+    service = """[
             {
                 "type": "didcommmessaging",
                 "serviceEndpoint": "https://example.com/endpoint",
@@ -27,16 +42,20 @@ def test_create_numalgo_2_positive():
                 "routingKeys": ["did:example:somemediator#somekey2"]
             }
             ]
-            '''
+            """
 
-    peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys, signing_keys=signing_keys,
-                                                service=service)
-    assert peer_did_algo_2 == 'did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc' \
-                              '.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V' \
-                              '.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg' \
-                              '.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlO' \
-                              'nNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9p' \
-                              'bnQyIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTIiXX1d'
+    peer_did_algo_2 = create_peer_did_numalgo_2(
+        encryption_keys=encryption_keys, signing_keys=signing_keys, service=service
+    )
+    assert (
+        peer_did_algo_2
+        == "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
+        ".Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+        ".Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg"
+        ".SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlO"
+        "nNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9p"
+        "bnQyIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTIiXX1d"
+    )
     assert is_peer_did(peer_did_algo_2)
 
 
@@ -45,292 +64,447 @@ def test_create_numalgo_2_without_encryption_keys():
     signing_keys = [
         PublicKeyAuthentication(
             encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58),
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
         PublicKeyAuthentication(
             encoded_value="3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
-    service = '''{
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
+    ]
+    service = """{
         "type": "didcommmessaging",
         "serviceEndpoint": "https://example.com/endpoint",
         "routingKeys": ["did:example:somemediator#somekey"]
         }
-        '''
+        """
 
-    peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys, signing_keys=signing_keys,
-                                                service=service)
-    assert peer_did_algo_2 == 'did:peer:2.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V' \
-                              '.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg' \
-                              '.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0='
+    peer_did_algo_2 = create_peer_did_numalgo_2(
+        encryption_keys=encryption_keys, signing_keys=signing_keys, service=service
+    )
+    assert (
+        peer_did_algo_2
+        == "did:peer:2.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+        ".Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg"
+        ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0="
+    )
     assert is_peer_did(peer_did_algo_2)
 
 
 def test_create_numalgo_2_without_signing_keys():
-    encryption_keys = [PublicKeyAgreement(encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
-                                          type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58)]
+    encryption_keys = [
+        PublicKeyAgreement(
+            encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
     signing_keys = []
-    service = '''{
+    service = """{
         "type": "didcommmessaging",
         "serviceEndpoint": "https://example.com/endpoint",
         "routingKeys": ["did:example:somemediator#somekey"]
         }
-        '''
+        """
 
-    peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys, signing_keys=signing_keys,
-                                                service=service)
-    assert peer_did_algo_2 == 'did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc' \
-                              '.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0='
+    peer_did_algo_2 = create_peer_did_numalgo_2(
+        encryption_keys=encryption_keys, signing_keys=signing_keys, service=service
+    )
+    assert (
+        peer_did_algo_2
+        == "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
+        ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0="
+    )
     assert is_peer_did(peer_did_algo_2)
 
 
 def test_create_numalgo_2_wrong_encryption_key():
-    encryption_keys = [PublicKeyAgreement(encoded_value="....",
-                                          type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58)]
+    encryption_keys = [
+        PublicKeyAgreement(
+            encoded_value="....",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
     signing_keys = [
         PublicKeyAuthentication(
             encoded_value="zXwpBnMdCm1cLmKuzgESn29nqnonp1ioqrQMRHNsmjMypp",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58),
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
         PublicKeyAuthentication(
             encoded_value="zx8xB2pv7cw8q1PdDacSrdWE3dtB9f7Nxk886mdzNFoPtY",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
-    service = '''{
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
+    ]
+    service = """{
         "type": "didcommmessaging",
         "serviceEndpoint": "https://example.com/endpoint",
         "routingKeys": ["did:example:somemediator#somekey"]
         }
-        '''
+        """
 
     with pytest.raises(ValueError):
-        peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys, signing_keys=signing_keys,
-                                                    service=service)
+        peer_did_algo_2 = create_peer_did_numalgo_2(
+            encryption_keys=encryption_keys, signing_keys=signing_keys, service=service
+        )
 
 
 def test_create_numalgo_2_wrong_signing_key():
-    encryption_keys = [PublicKeyAgreement(encoded_value="6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
-                                          type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58)]
+    encryption_keys = [
+        PublicKeyAgreement(
+            encoded_value="6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
     signing_keys = [
         PublicKeyAuthentication(
             encoded_value=".......",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58),
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
         PublicKeyAuthentication(
             encoded_value="zx8xB2pv7cw8q1PdDacSrdWE3dtB9f7Nxk886mdzNFoPtY",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
-    service = '''{
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
+    ]
+    service = """{
         "type": "didcommmessaging",
         "serviceEndpoint": "https://example.com/endpoint",
         "routingKeys": ["did:example:somemediator#somekey"]
         }
-        '''
+        """
 
     with pytest.raises(ValueError):
-        peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys, signing_keys=signing_keys,
-                                                    service=service)
+        peer_did_algo_2 = create_peer_did_numalgo_2(
+            encryption_keys=encryption_keys, signing_keys=signing_keys, service=service
+        )
 
 
 def test_create_numalgo_2_wrong_service():
-    encryption_keys = [PublicKeyAgreement(encoded_value="6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
-                                          type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58)]
+    encryption_keys = [
+        PublicKeyAgreement(
+            encoded_value="6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
     signing_keys = [
         PublicKeyAuthentication(
             encoded_value=".......",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58),
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
         PublicKeyAuthentication(
             encoded_value="zx8xB2pv7cw8q1PdDacSrdWE3dtB9f7Nxk886mdzNFoPtY",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
-    service = '.......'
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
+    ]
+    service = "......."
 
     with pytest.raises(ValueError):
-        peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys, signing_keys=signing_keys,
-                                                    service=service)
+        peer_did_algo_2 = create_peer_did_numalgo_2(
+            encryption_keys=encryption_keys, signing_keys=signing_keys, service=service
+        )
 
 
 def test_create_numalgo_2_encryption_key_as_signing():
-    encryption_keys = [PublicKeyAgreement(encoded_value="6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
-                                          type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58)]
-    service = '''{
+    encryption_keys = [
+        PublicKeyAgreement(
+            encoded_value="6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
+    service = """{
         "type": "didcommmessaging",
         "serviceEndpoint": "https://example.com/endpoint",
         "routingKeys": ["did:example:somemediator#somekey"]
         }
-        '''
+        """
     with pytest.raises(ValueError):
-        peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys, signing_keys=encryption_keys,
-                                                    service=service)
+        peer_did_algo_2 = create_peer_did_numalgo_2(
+            encryption_keys=encryption_keys,
+            signing_keys=encryption_keys,
+            service=service,
+        )
 
 
 def test_create_numalgo_2_signing_key_as_encryption():
     signing_keys = [
         PublicKeyAuthentication(
             encoded_value="zXwpBnMdCm1cLmKuzgESn29nqnonp1ioqrQMRHNsmjMypp",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58),
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
         PublicKeyAuthentication(
             encoded_value="zx8xB2pv7cw8q1PdDacSrdWE3dtB9f7Nxk886mdzNFoPtY",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
-    service = '''{
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
+    ]
+    service = """{
         "type": "didcommmessaging",
         "serviceEndpoint": "https://example.com/endpoint",
         "routingKeys": ["did:example:somemediator#somekey"]
         }
-        '''
+        """
     with pytest.raises(TypeError):
-        peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=signing_keys, signing_keys=signing_keys,
-                                                    service=service)
+        peer_did_algo_2 = create_peer_did_numalgo_2(
+            encryption_keys=signing_keys, signing_keys=signing_keys, service=service
+        )
 
 
 def test_create_numalgo_2_service_is_None():
-    encryption_keys = [PublicKeyAgreement(encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
-                                          type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58)]
+    encryption_keys = [
+        PublicKeyAgreement(
+            encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
     signing_keys = [
         PublicKeyAuthentication(
             encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58),
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
         PublicKeyAuthentication(
             encoded_value="3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
+    ]
     service = None
 
-    peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys, signing_keys=signing_keys,
-                                                service=service)
-    assert peer_did_algo_2 == 'did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc' \
-                              '.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V' \
-                              '.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg'
+    peer_did_algo_2 = create_peer_did_numalgo_2(
+        encryption_keys=encryption_keys, signing_keys=signing_keys, service=service
+    )
+    assert (
+        peer_did_algo_2
+        == "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
+        ".Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+        ".Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg"
+    )
     assert is_peer_did(peer_did_algo_2)
 
 
 def test_create_numalgo_2_encryption_and_signing_keys_are_1_element_array():
-    encryption_keys = [PublicKeyAgreement(encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
-                                          type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58)]
-    signing_keys = [PublicKeyAuthentication(
-        encoded_value="3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J",
-        type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
-    service = '''{
+    encryption_keys = [
+        PublicKeyAgreement(
+            encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
+    signing_keys = [
+        PublicKeyAuthentication(
+            encoded_value="3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J",
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
+    service = """{
         "type": "didcommmessaging",
         "serviceEndpoint": "https://example.com/endpoint",
         "routingKeys": ["did:example:somemediator#somekey"]
         }
-        '''
+        """
 
-    peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys, signing_keys=signing_keys,
-                                                service=service)
+    peer_did_algo_2 = create_peer_did_numalgo_2(
+        encryption_keys=encryption_keys, signing_keys=signing_keys, service=service
+    )
     assert is_peer_did(peer_did_algo_2)
 
 
 def test_create_numalgo_2_encryption_and_signing_keys_are_more_than_1_element_array():
-    encryption_keys = [PublicKeyAgreement(encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
-                                          type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58),
-                       PublicKeyAgreement(
-                           encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
-                           type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58)
-                       ]
+    encryption_keys = [
+        PublicKeyAgreement(
+            encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        ),
+        PublicKeyAgreement(
+            encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        ),
+    ]
     signing_keys = [
         PublicKeyAuthentication(
             encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58),
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
         PublicKeyAuthentication(
             encoded_value="3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
-    service = '''{
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
+    ]
+    service = """{
         "type": "didcommmessaging",
         "serviceEndpoint": "https://example.com/endpoint",
         "routingKeys": ["did:example:somemediator#somekey"]
         }
-        '''
+        """
 
-    peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys, signing_keys=signing_keys,
-                                                service=service)
+    peer_did_algo_2 = create_peer_did_numalgo_2(
+        encryption_keys=encryption_keys, signing_keys=signing_keys, service=service
+    )
     assert is_peer_did(peer_did_algo_2)
 
 
 def test_create_numalgo_2_service_has_more_fields_than_in_conversion_table():
-    encryption_keys = [PublicKeyAgreement(encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
-                                          type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58)]
+    encryption_keys = [
+        PublicKeyAgreement(
+            encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
     signing_keys = [
         PublicKeyAuthentication(
             encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58),
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
         PublicKeyAuthentication(
             encoded_value="3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
-    service = '''{
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
+    ]
+    service = """{
         "type": "didcommmessaging",
         "serviceEndpoint": "https://example.com/endpoint",
         "routingKeys": ["did:example:somemediator#somekey"],
         "example1": "myExample1",
         "example2": "myExample2"
         }
-        '''
+        """
 
-    peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys, signing_keys=signing_keys,
-                                                service=service)
+    peer_did_algo_2 = create_peer_did_numalgo_2(
+        encryption_keys=encryption_keys, signing_keys=signing_keys, service=service
+    )
     assert is_peer_did(peer_did_algo_2)
 
 
 def test_create_numalgo_2_service_is_not_didcommmessaging():
-    encryption_keys = [PublicKeyAgreement(encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
-                                          type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58)]
+    encryption_keys = [
+        PublicKeyAgreement(
+            encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
     signing_keys = [
         PublicKeyAuthentication(
             encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58),
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
         PublicKeyAuthentication(
             encoded_value="3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
-    service = '''{
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
+    ]
+    service = """{
         "type": "example1",
         "serviceEndpoint": "https://example.com/endpoint",
         "routingKeys": ["did:example:somemediator#somekey"]
         }
-        '''
+        """
 
-    peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys, signing_keys=signing_keys,
-                                                service=service)
+    peer_did_algo_2 = create_peer_did_numalgo_2(
+        encryption_keys=encryption_keys, signing_keys=signing_keys, service=service
+    )
     assert is_peer_did(peer_did_algo_2)
 
 
 def test_create_numalgo_2_service_is_empty_string():
-    encryption_keys = [PublicKeyAgreement(encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
-                                          type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58)]
+    encryption_keys = [
+        PublicKeyAgreement(
+            encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
     signing_keys = [
         PublicKeyAuthentication(
             encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58),
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
         PublicKeyAuthentication(
             encoded_value="3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
-    service = ''
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
+    ]
+    service = ""
 
     with pytest.raises(ValueError):
-        peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys, signing_keys=signing_keys,
-                                                    service=service)
+        peer_did_algo_2 = create_peer_did_numalgo_2(
+            encryption_keys=encryption_keys, signing_keys=signing_keys, service=service
+        )
 
 
 def test_create_numalgo_2_service_is_empty_array():
-    encryption_keys = [PublicKeyAgreement(encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
-                                          type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58)]
+    encryption_keys = [
+        PublicKeyAgreement(
+            encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
     signing_keys = [
         PublicKeyAuthentication(
             encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58),
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
         PublicKeyAuthentication(
             encoded_value="3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
+    ]
     service = []
 
     with pytest.raises(TypeError):
-        peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys, signing_keys=signing_keys,
-                                                    service=service)
+        peer_did_algo_2 = create_peer_did_numalgo_2(
+            encryption_keys=encryption_keys, signing_keys=signing_keys, service=service
+        )
 
 
 def test_create_numalgo_2_different_types_of_service():
-    encryption_keys = [PublicKeyAgreement(encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
-                                          type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58)]
+    encryption_keys = [
+        PublicKeyAgreement(
+            encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
     signing_keys = [
         PublicKeyAuthentication(
             encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58),
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
         PublicKeyAuthentication(
             encoded_value="3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
-    service = '''
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
+    ]
+    service = """
         [
                   {
                       "type": "example1",
@@ -343,205 +517,310 @@ def test_create_numalgo_2_different_types_of_service():
                      "routingKeys": ["did:example:somemediator#somekey2"]
                  }
         ]
-        '''
+        """
 
-    peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys, signing_keys=signing_keys,
-                                                service=service)
+    peer_did_algo_2 = create_peer_did_numalgo_2(
+        encryption_keys=encryption_keys, signing_keys=signing_keys, service=service
+    )
     assert is_peer_did(peer_did_algo_2)
 
 
 def test_create_numalgo_2_malformed_encryption_key_not_base58_encoded():
-    encryption_keys = [PublicKeyAgreement(encoded_value="JhNWeSVLMYcc0k7iopQW4guaSJTojqpMEELgSLhKwRr",
-                                          type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58)]
+    encryption_keys = [
+        PublicKeyAgreement(
+            encoded_value="JhNWeSVLMYcc0k7iopQW4guaSJTojqpMEELgSLhKwRr",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
     signing_keys = [
         PublicKeyAuthentication(
             encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58),
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
         PublicKeyAuthentication(
             encoded_value="3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
-    service = '''{
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
+    ]
+    service = """{
             "type": "didcommmessaging",
             "serviceEndpoint": "https://example.com/endpoint",
             "routingKeys": ["did:example:somemediator#somekey"]
             }
-            '''
+            """
     with pytest.raises(ValueError):
-        peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys, signing_keys=signing_keys,
-                                                    service=service)
+        peer_did_algo_2 = create_peer_did_numalgo_2(
+            encryption_keys=encryption_keys, signing_keys=signing_keys, service=service
+        )
 
 
 def test_create_numalgo_2_malformed_short_encryption_key():
-    encryption_keys = [PublicKeyAgreement(encoded_value="JhNWeSV",
-                                          type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58)]
+    encryption_keys = [
+        PublicKeyAgreement(
+            encoded_value="JhNWeSV",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
     signing_keys = [
         PublicKeyAuthentication(
             encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58),
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
         PublicKeyAuthentication(
             encoded_value="3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
-    service = '''{
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
+    ]
+    service = """{
             "type": "didcommmessaging",
             "serviceEndpoint": "https://example.com/endpoint",
             "routingKeys": ["did:example:somemediator#somekey"]
             }
-            '''
+            """
     with pytest.raises(ValueError):
-        peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys, signing_keys=signing_keys,
-                                                    service=service)
+        peer_did_algo_2 = create_peer_did_numalgo_2(
+            encryption_keys=encryption_keys, signing_keys=signing_keys, service=service
+        )
 
 
 def test_create_numalgo_2_malformed_long_encryption_key():
-    encryption_keys = [PublicKeyAgreement(encoded_value="JhNWeSVJhNWeSVJhNWeSVJhNWeSVJhNWeSVJhNWeSVJhNWeSVJhNWeSVJhNWe",
-                                          type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58)]
+    encryption_keys = [
+        PublicKeyAgreement(
+            encoded_value="JhNWeSVJhNWeSVJhNWeSVJhNWeSVJhNWeSVJhNWeSVJhNWeSVJhNWeSVJhNWe",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
     signing_keys = [
         PublicKeyAuthentication(
             encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58),
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
         PublicKeyAuthentication(
             encoded_value="3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
-    service = '''{
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
+    ]
+    service = """{
             "type": "didcommmessaging",
             "serviceEndpoint": "https://example.com/endpoint",
             "routingKeys": ["did:example:somemediator#somekey"]
             }
-            '''
+            """
     with pytest.raises(ValueError):
-        peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys, signing_keys=signing_keys,
-                                                    service=service)
+        peer_did_algo_2 = create_peer_did_numalgo_2(
+            encryption_keys=encryption_keys, signing_keys=signing_keys, service=service
+        )
 
 
 def test_create_numalgo_2_malformed_encryption_key_empty():
-    encryption_keys = [PublicKeyAgreement(encoded_value="",
-                                          type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58)]
+    encryption_keys = [
+        PublicKeyAgreement(
+            encoded_value="",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
     signing_keys = [
         PublicKeyAuthentication(
             encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58),
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
         PublicKeyAuthentication(
             encoded_value="3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
-    service = '''{
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
+    ]
+    service = """{
             "type": "didcommmessaging",
             "serviceEndpoint": "https://example.com/endpoint",
             "routingKeys": ["did:example:somemediator#somekey"]
             }
-            '''
+            """
     with pytest.raises(ValueError):
-        peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys, signing_keys=signing_keys,
-                                                    service=service)
+        peer_did_algo_2 = create_peer_did_numalgo_2(
+            encryption_keys=encryption_keys, signing_keys=signing_keys, service=service
+        )
 
 
 def test_create_numalgo_2_invalid_encryption_key_type():
-    encryption_keys = [PublicKeyAuthentication(
-        encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
-        type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
+    encryption_keys = [
+        PublicKeyAuthentication(
+            encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
     signing_keys = [
         PublicKeyAuthentication(
             encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58),
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
         PublicKeyAuthentication(
             encoded_value="3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J",
-            type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
-    service = '''{
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        ),
+    ]
+    service = """{
         "type": "didcommmessaging",
         "serviceEndpoint": "https://example.com/endpoint",
         "routingKeys": ["did:example:somemediator#somekey"]
         }
-        '''
+        """
 
     with pytest.raises(TypeError):
-        peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys, signing_keys=signing_keys,
-                                                    service=service)
+        peer_did_algo_2 = create_peer_did_numalgo_2(
+            encryption_keys=encryption_keys, signing_keys=signing_keys, service=service
+        )
 
 
 def test_create_numalgo_2_malformed_signing_key_not_base58_encoded():
-    encryption_keys = [PublicKeyAgreement(encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
-                                          type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58)]
-    signing_keys = [PublicKeyAuthentication(
-        encoded_value="3M5RCDjPTWPkKSN3sxU0mMqHbmRPegYP1tjcKyrDbt9J",
-        type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
-    service = '''{
+    encryption_keys = [
+        PublicKeyAgreement(
+            encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
+    signing_keys = [
+        PublicKeyAuthentication(
+            encoded_value="3M5RCDjPTWPkKSN3sxU0mMqHbmRPegYP1tjcKyrDbt9J",
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
+    service = """{
         "type": "didcommmessaging",
         "serviceEndpoint": "https://example.com/endpoint",
         "routingKeys": ["did:example:somemediator#somekey"]
         }
-        '''
+        """
 
     with pytest.raises(ValueError):
-        peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys, signing_keys=signing_keys,
-                                                    service=service)
+        peer_did_algo_2 = create_peer_did_numalgo_2(
+            encryption_keys=encryption_keys, signing_keys=signing_keys, service=service
+        )
 
 
 def test_create_numalgo_2_malformed_short_signing_key():
-    encryption_keys = [PublicKeyAgreement(encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
-                                          type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58)]
-    signing_keys = [PublicKeyAuthentication(
-        encoded_value="ByHnpUCF",
-        type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
-    service = '''{
+    encryption_keys = [
+        PublicKeyAgreement(
+            encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
+    signing_keys = [
+        PublicKeyAuthentication(
+            encoded_value="ByHnpUCF",
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
+    service = """{
         "type": "didcommmessaging",
         "serviceEndpoint": "https://example.com/endpoint",
         "routingKeys": ["did:example:somemediator#somekey"]
         }
-        '''
+        """
 
     with pytest.raises(ValueError):
-        peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys, signing_keys=signing_keys,
-                                                    service=service)
+        peer_did_algo_2 = create_peer_did_numalgo_2(
+            encryption_keys=encryption_keys, signing_keys=signing_keys, service=service
+        )
 
 
 def test_create_numalgo_2_malformed_long_signing_key():
-    encryption_keys = [PublicKeyAgreement(encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
-                                          type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58)]
-    signing_keys = [PublicKeyAuthentication(
-        encoded_value="3M5RCDjxUmmMqHbmRPegYPPTWPkKSN3sxUmmMqHbmRPegYPxUmmMqHbmRPegYP1tjcKxUmmMqHbmRPegYPyrDbt9J",
-        type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
-    service = '''{
+    encryption_keys = [
+        PublicKeyAgreement(
+            encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
+    signing_keys = [
+        PublicKeyAuthentication(
+            encoded_value="3M5RCDjxUmmMqHbmRPegYPPTWPkKSN3sxUmmMqHbmRPegYPxUmmMqHbmRPegYP1tjcKxUmmMqHbmRPegYPyrDbt9J",
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
+    service = """{
         "type": "didcommmessaging",
         "serviceEndpoint": "https://example.com/endpoint",
         "routingKeys": ["did:example:somemediator#somekey"]
         }
-        '''
+        """
 
     with pytest.raises(ValueError):
-        peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys, signing_keys=signing_keys,
-                                                    service=service)
+        peer_did_algo_2 = create_peer_did_numalgo_2(
+            encryption_keys=encryption_keys, signing_keys=signing_keys, service=service
+        )
 
 
 def test_create_numalgo_2_malformed_empty_signing_key():
-    encryption_keys = [PublicKeyAgreement(encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
-                                          type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58)]
-    signing_keys = [PublicKeyAuthentication(
-        encoded_value="",
-        type=PublicKeyTypeAuthentication.ED25519, encoding_type=EncodingType.BASE58)]
-    service = '''{
+    encryption_keys = [
+        PublicKeyAgreement(
+            encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
+    signing_keys = [
+        PublicKeyAuthentication(
+            encoded_value="",
+            type=PublicKeyTypeAuthentication.ED25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
+    service = """{
         "type": "didcommmessaging",
         "serviceEndpoint": "https://example.com/endpoint",
         "routingKeys": ["did:example:somemediator#somekey"]
         }
-        '''
+        """
 
     with pytest.raises(ValueError):
-        peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys, signing_keys=signing_keys,
-                                                    service=service)
+        peer_did_algo_2 = create_peer_did_numalgo_2(
+            encryption_keys=encryption_keys, signing_keys=signing_keys, service=service
+        )
 
 
-def test_create_numalgo_0_invalid_inception_key_type():
-    encryption_keys = [PublicKeyAgreement(encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
-                                          type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58)]
-    signing_keys = [PublicKeyAgreement(
-        encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
-        type=PublicKeyTypeAgreement.X25519, encoding_type=EncodingType.BASE58)]
-    service = '''{
+def test_create_numalgo_2_invalid_inception_key_type():
+    encryption_keys = [
+        PublicKeyAgreement(
+            encoded_value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
+    signing_keys = [
+        PublicKeyAgreement(
+            encoded_value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
+            type=PublicKeyTypeAgreement.X25519,
+            encoding_type=EncodingType.BASE58,
+        )
+    ]
+    service = """{
         "type": "didcommmessaging",
         "serviceEndpoint": "https://example.com/endpoint",
         "routingKeys": ["did:example:somemediator#somekey"]
         }
-        '''
+        """
 
     with pytest.raises(TypeError):
-        peer_did_algo_2 = create_peer_did_numalgo_2(encryption_keys=encryption_keys, signing_keys=signing_keys,
-                                                    service=service)
+        peer_did_algo_2 = create_peer_did_numalgo_2(
+            encryption_keys=encryption_keys, signing_keys=signing_keys, service=service
+        )

--- a/tests/test_peer_did_utils.py
+++ b/tests/test_peer_did_utils.py
@@ -2,29 +2,33 @@ from peerdid.peer_did_utils import _encode_service
 
 
 def test_encode_service():
-    service = '''{
+    service = """{
         "type": "didcommmessaging",
         "serviceEndpoint": "https://example.com/endpoint",
         "routingKeys": ["did:example:somemediator#somekey"]
         }
-        '''
+        """
 
-    assert _encode_service(
-        service) == ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0="
+    assert (
+        _encode_service(service)
+        == ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0="
+    )
 
 
 def test_encode_service_without_routing_keys():
-    service = '''{
+    service = """{
         "type": "didcommmessaging",
         "serviceEndpoint": "https://example.com/endpoint",
         }
-        '''
-    assert _encode_service(
-        service) == ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsfQ=="
+        """
+    assert (
+        _encode_service(service)
+        == ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsfQ=="
+    )
 
 
 def test_encode_service_with_multiple_entries_list():
-    services = '''
+    services = """
             [
                 {
                     "type": "didcommmessaging",
@@ -37,9 +41,12 @@ def test_encode_service_with_multiple_entries_list():
                     "routingKeys": ["did:example:somemediator#somekey2"]
                 }
             ]
-            '''
+            """
 
     encoded_services = _encode_service(services)
-    assert encoded_services == '.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlO' \
-                               'nNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9p' \
-                               'bnQyIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTIiXX1d'
+    assert (
+        encoded_services
+        == ".SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlO"
+        "nNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9p"
+        "bnQyIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTIiXX1d"
+    )

--- a/tests/test_resolve_peer_did_numalgo_0.py
+++ b/tests/test_resolve_peer_did_numalgo_0.py
@@ -7,7 +7,7 @@ from peerdid.peer_did import resolve_peer_did
 
 def test_resolve_positive():
     expected_value = json.loads(
-        '''
+        """
            {
                "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
                "authentication": {
@@ -17,42 +17,61 @@ def test_resolve_positive():
                    "publicKeyBase58": "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
                }
            }
-        ''')
+        """
+    )
 
-    real_value = json.loads(resolve_peer_did(peer_did='did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V'))
+    real_value = json.loads(
+        resolve_peer_did(
+            peer_did="did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+        )
+    )
     assert real_value == expected_value
 
 
 def test_resolve_unsupported_did_method():
     with pytest.raises(ValueError):
-        resolve_peer_did(peer_did='did:key:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V')
+        resolve_peer_did(
+            peer_did="did:key:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+        )
 
 
 def test_resolve_invalid_peer_did():
     with pytest.raises(ValueError):
-        resolve_peer_did(peer_did='did:peer:0z6MkqRYqQiSBytw86Qbs2ZWUkGv22od935YF4s8M7V')
+        resolve_peer_did(
+            peer_did="did:peer:0z6MkqRYqQiSBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+        )
 
 
 def test_resolve_unsupported_numalgo_code():
     with pytest.raises(ValueError):
-        resolve_peer_did(peer_did='did:peer:1z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V')
+        resolve_peer_did(
+            peer_did="did:peer:1z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+        )
 
 
 def test_resolve_numalgo_0_malformed_base58_encoding():
     with pytest.raises(ValueError):
-        resolve_peer_did(peer_did='did:peer:0z6MkqRYqQiSgvZQd0Bytw86Qbs2ZWUkGv22od935YF4s8M7V')
+        resolve_peer_did(
+            peer_did="did:peer:0z6MkqRYqQiSgvZQd0Bytw86Qbs2ZWUkGv22od935YF4s8M7V"
+        )
 
 
 def test_resolve_numalgo_0_unsupported_transform_code():
     with pytest.raises(ValueError):
-        resolve_peer_did(peer_did='did:peer:0a6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V')
+        resolve_peer_did(
+            peer_did="did:peer:0a6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+        )
 
 
 def test_resolve_numalgo_0_malformed_multicodec_encoding():
     with pytest.raises(ValueError):
-        resolve_peer_did(peer_did='did:peer:0z6666RYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V')
+        resolve_peer_did(
+            peer_did="did:peer:0z6666RYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+        )
 
 
 def test_resolve_numalgo_0_invalid_key_type():
     with pytest.raises(ValueError):
-        resolve_peer_did(peer_did='did:peer:0z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc')
+        resolve_peer_did(
+            peer_did="did:peer:0z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
+        )

--- a/tests/test_resolve_peer_did_numalgo_2.py
+++ b/tests/test_resolve_peer_did_numalgo_2.py
@@ -7,63 +7,79 @@ from peerdid.peer_did import resolve_peer_did
 
 def test_resolve_numalgo_2_unsupported_transform_code():
     with pytest.raises(ValueError):
-        resolve_peer_did('did:peer:2.Ea6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc'
-                         '.Va6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V'
-                         '.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=')
+        resolve_peer_did(
+            "did:peer:2.Ea6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
+            ".Va6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+            ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0="
+        )
 
 
 def test_resolve_numalgo_2_signing_malformed_base58_encoding():
     with pytest.raises(ValueError):
-        resolve_peer_did('did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc'
-                         '.Vz6MkqRYqQiSgvZQdnBytw86Qbs0ZWUkGv22od935YF4s8M7V'
-                         '.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=')
+        resolve_peer_did(
+            "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
+            ".Vz6MkqRYqQiSgvZQdnBytw86Qbs0ZWUkGv22od935YF4s8M7V"
+            ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0="
+        )
 
 
 def test_resolve_numalgo_2_encryption_malformed_base58_encoding():
     with pytest.raises(ValueError):
-        resolve_peer_did('did:peer:2.Ez6LSbysY2xFMRpG0hb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc'
-                         '.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V'
-                         '.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=')
+        resolve_peer_did(
+            "did:peer:2.Ez6LSbysY2xFMRpG0hb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
+            ".Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+            ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0="
+        )
 
 
 def test_resolve_numalgo_2_signing_malformed_multicodec_encoding():
     with pytest.raises(ValueError):
-        resolve_peer_did('did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc'
-                         '.Vz6666YqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V'
-                         '.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=')
+        resolve_peer_did(
+            "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
+            ".Vz6666YqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+            ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0="
+        )
 
 
 def test_resolve_numalgo_2_encryption_malformed_multicodec_encoding():
     with pytest.raises(ValueError):
-        resolve_peer_did('did:peer:2.Ez7777sY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc'
-                         '.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V'
-                         '.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=')
+        resolve_peer_did(
+            "did:peer:2.Ez7777sY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
+            ".Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+            ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0="
+        )
 
 
 def test_resolve_numalgo_2_signing_invalid_key_type():
     with pytest.raises(ValueError):
-        resolve_peer_did('did:peer:2.Vz6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc'
-                         '.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V'
-                         '.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=')
+        resolve_peer_did(
+            "did:peer:2.Vz6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
+            ".Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+            ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0="
+        )
 
 
 def test_resolve_numalgo_2_encryption_invalid_key_type():
     with pytest.raises(ValueError):
-        resolve_peer_did('did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc'
-                         '.Ez6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V'
-                         '.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=')
+        resolve_peer_did(
+            "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
+            ".Ez6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+            ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0="
+        )
 
 
 def test_resolve_numalgo_2_malformed_service_encoding():
     with pytest.raises(ValueError):
-        resolve_peer_did('did:peer:2.Ea6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc'
-                         '.Va6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V'
-                         '.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9\\GxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=')
+        resolve_peer_did(
+            "did:peer:2.Ea6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
+            ".Va6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+            ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9\\GxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0="
+        )
 
 
 def test_resolve_numalgo_2_positive_service_is_1_element_array():
     expected_value = json.loads(
-        '''
+        """
         {
            "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
            "authentication": [
@@ -99,19 +115,24 @@ def test_resolve_numalgo_2_positive_service_is_1_element_array():
                }
            ]
        }
-       ''')
+       """
+    )
 
-    real_value = json.loads(resolve_peer_did(
-        'did:peer:2'
-        '.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc'
-        '.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V'
-        '.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg'
-        '.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0='))
+    real_value = json.loads(
+        resolve_peer_did(
+            "did:peer:2"
+            ".Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
+            ".Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+            ".Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg"
+            ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0="
+        )
+    )
     assert real_value == expected_value
 
 
 def test_resolve_numalgo_2_positive_service_is_2_element_array():
-    expected_value = json.loads('''
+    expected_value = json.loads(
+        """
     {
         "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=",
         "authentication": [
@@ -149,12 +170,16 @@ def test_resolve_numalgo_2_positive_service_is_2_element_array():
             }
         ]
     }
-    ''')
+    """
+    )
 
-    real_value = json.loads(resolve_peer_did(
-        'did:peer:2'
-        '.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud'
-        '.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V'
-        '.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0='))
+    real_value = json.loads(
+        resolve_peer_did(
+            "did:peer:2"
+            ".Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud"
+            ".Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+            ".SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0="
+        )
+    )
 
     assert real_value == expected_value


### PR DESCRIPTION
- workflows updated:
fixed a bug with undefined os in tests.yml and codestyle.yml
removed black-formatter
- black-formatted code and flake8-checked: 
every .py file was black-formatted and then checked with flake8
- python 3.6 and 3.7 features removed
removed f-Strings feature like `print(f'{}')` (Python 3.6+ feature)
removed dataclasses (Python 3.7+ feature), use NamedTuple instead of it