### PR TITLE
adds release workflows

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -11,29 +11,37 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - name: Set up Python 3.6
         uses: actions/setup-python@v2
         with:
           python-version: 3.6
+
       - name: Install black
         run: |
           pip install black
+
       - name: Black Format Check
         run: |
           black --check .
+
+
   flake8_py3:
     needs: format
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.6
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+
       - name: Lint with flake8
         run: |
           pip install flake8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,8 +154,33 @@ jobs:
           ls
         shell: bash
 
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.4.2
+      # NOTE uncomment once community actions are allowed for the github org
+      # - name: Publish to PyPI
+      #   uses: pypa/gh-action-pypi-publish@v1.4.2
+      #   with:
+      #       user: __token__
+      #       password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - uses: actions/setup-python@v2
         with:
-            user: __token__
-            password: ${{ secrets.PYPI_API_TOKEN }}
+          python-version: '3.x'
+
+      - name: Prepare python env
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade twine
+        shell: bash
+
+      # NOTE uncomment once test pypi account is available
+      # - name: Publish to TestPyPI
+      #   if: github.ref != 'refs/heads/stable'
+      #   env:
+      #     TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+      #   run: python -m twine upload --non-interactive --username __token__ --repository testpypi dist/*
+      #   shell: bash
+
+      - name: Publish to PyPI
+        env:
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: python -m twine upload --non-interactive --username __token__ dist/*
+        shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,15 +171,16 @@ jobs:
           python -m pip install --upgrade twine
         shell: bash
 
-      # NOTE uncomment once test pypi account is available
-      # - name: Publish to TestPyPI
-      #   if: github.ref != 'refs/heads/stable'
-      #   env:
-      #     TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
-      #   run: python -m twine upload --non-interactive --username __token__ --repository testpypi dist/*
-      #   shell: bash
+      # TODO add non-stable branch triggers once TestPyPI account is created
+      - name: Publish to TestPyPI
+        if: github.ref != 'refs/heads/stable'
+        env:
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        run: python -m twine upload --non-interactive --username __token__ --repository testpypi dist/*
+        shell: bash
 
       - name: Publish to PyPI
+        # if: github.ref == 'refs/heads/stable'
         env:
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: python -m twine upload --non-interactive --username __token__ dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,16 +12,19 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       current_version: ${{ steps.current_version.outputs.current_version }}
-      version_latest: ${{ steps.version_latest.outputs.version_latest }}
-      already_released: ${{ steps.version_latest.outputs.version_latest == steps.current_version.outputs.current_version }}
+      release_info: ${{ steps.release_info.outputs.release_info }}
+      asset_tgz_url: ${{ steps.release_info.outputs.asset_tgz_url }}
+      asset_whl_url: ${{ steps.release_info.outputs.asset_whl_url }}
+      upload_url:  ${{ steps.release_info.outputs.upload_url }}
       already_in_pypi: ${{ steps.check_in_pypi.outputs.pypi_versions != '' }}
+
     steps:
+      - uses: actions/checkout@v2
+
       - uses: actions/setup-python@v2
         with:
           python-version: '3.x'
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+
       - name: Get current version
         id: current_version
         run: |
@@ -30,13 +33,30 @@ jobs:
           echo "$out"
           echo "::set-output name=current_version::$out"
         shell: bash
-      - name: Get latest tag
-        id: version_latest
+
+      - name: Get release info
+        id: release_info
         run: |
-          out="$(git describe --abbrev=0 --tags | cut -d'v' -f 2)"
-          echo "$out"
-          echo "::set-output name=version_latest::$out"
+          release_info="$(curl -s https://api.github.com/repos/${{ github.repository }}/releases \
+              | jq '.[] | select(.name == "v${{ steps.current_version.outputs.current_version }}")')"
+          echo "::set-output name=release_info::$release_info"
+          echo "$release_info"
+
+          asset_tgz_url="$(echo "$release_info" \
+              | jq -r '.assets[] | select(.name | match("^${{ env.PKG_NAME }}.*\\.tar.gz$")) | .browser_download_url')"
+          echo "::set-output name=asset_tgz_url::$asset_tgz_url"
+          echo "$asset_tgz_url"
+
+          asset_whl_url="$(echo "$release_info" \
+              | jq -r '.assets[] | select(.name | match("^${{ env.PKG_NAME }}.*\\.whl$")) | .browser_download_url')"
+          echo "::set-output name=asset_whl_url::$asset_whl_url"
+          echo "$asset_whl_url"
+
+          upload_url="$(echo "$release_info" | jq -r '.upload_url')"
+          echo "::set-output name=upload_url::$upload_url"
+          echo "$upload_url"
         shell: bash
+
       - name: check if already deployed to PyPI
         id: check_in_pypi
         # Note. other options:
@@ -54,30 +74,76 @@ jobs:
     name: GitHub Release
     runs-on: ubuntu-latest
     needs: checks
-    if: github.event_name == 'push' && github.ref == 'refs/heads/stable'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/stable'
     steps:
       - uses: actions/checkout@v2
+
       - name: build dist
-        if: needs.checks.outputs.already_released == 'false'
+        id: build_assets
+        if: ${{ !(needs.checks.outputs.asset_tgz_url && needs.checks.outputs.asset_whl_url) }}
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade build
           python -m build
-      - uses: ncipollo/release-action@v1
-        if: needs.checks.outputs.already_released == 'false'
+          ls dist
+
+          asset_tgz_name="$(find dist -name '*.tar.gz' -printf '%f')"
+          echo "::set-output name=asset_tgz_name::$asset_tgz_name"
+
+          asset_whl_name="$(find dist -name '*.whl' -printf '%f')"
+          echo "::set-output name=asset_whl_name::$asset_whl_name"
+        shell: bash
+
+      - name: Create Release
+        id: create_release
+        if: ${{ ! needs.checks.outputs.release_info }}
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          artifacts: "dist/*"
-          tag: v${{ needs.checks.outputs.current_version }}
-          commit: stable
-          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: v${{ needs.checks.outputs.current_version }}
+          release_name: v${{ needs.checks.outputs.current_version }}
+
+      - name: Set upload url
+        id: upload_url
+        if: ${{ !(needs.checks.outputs.asset_tgz_url && needs.checks.outputs.asset_whl_url) }}
+        run: |
+          if [[ -n "${{ needs.checks.outputs.upload_url }}" ]]; then
+            echo "::set-output name=value::${{ needs.checks.outputs.upload_url }}"
+          else
+            echo "::set-output name=value::${{ steps.create_release.outputs.upload_url }}"
+          fi
+
+      - name: Upload the source archive
+        if: ${{ !needs.checks.outputs.asset_tgz_url }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.upload_url.outputs.value }}
+          asset_path: dist/${{ steps.build_assets.outputs.asset_tgz_name }}
+          asset_name: ${{ steps.build_assets.outputs.asset_tgz_name }}
+          asset_content_type: application/x-gtar
+
+      - name: Upload the wheel
+        if: ${{ !needs.checks.outputs.asset_whl_url }} 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.upload_url.outputs.value }}
+          asset_path: dist/${{ steps.build_assets.outputs.asset_whl_name }}
+          asset_name: ${{ steps.build_assets.outputs.asset_whl_name }}
+          asset_content_type: application/zip
 
   deploy-pypi:
     name: Deploy to PyPI
     runs-on: ubuntu-latest
     needs: [checks, release-github]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && needs.checks.outputs.already_in_pypi == 'false'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/stable' && needs.checks.outputs.already_in_pypi == 'false'
     steps:
       - uses: actions/checkout@v2
+
       - name: download GitHub artifacts
         run: |
           mkdir -p dist
@@ -87,6 +153,7 @@ jobs:
             | wget -i -
           ls
         shell: bash
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,36 +53,36 @@ jobs:
   release-github:
     name: GitHub Release
     runs-on: ubuntu-latest
-    needs: testjob1
+    needs: checks
     if: github.event_name == 'push' && github.ref == 'refs/heads/stable'
     steps:
       - uses: actions/checkout@v2
       - name: build dist
-        if: needs.testjob1.outputs.already_released == 'false'
+        if: needs.checks.outputs.already_released == 'false'
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade build
           python -m build
       - uses: ncipollo/release-action@v1
-        if: needs.testjob1.outputs.already_released == 'false'
+        if: needs.checks.outputs.already_released == 'false'
         with:
           artifacts: "dist/*"
-          tag: v${{ needs.testjob1.outputs.current_version }}
+          tag: v${{ needs.checks.outputs.current_version }}
           commit: stable
           token: ${{ secrets.GITHUB_TOKEN }}
 
   deploy-pypi:
     name: Deploy to PyPI
     runs-on: ubuntu-latest
-    needs: [testjob1, testjob4]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && needs.testjob1.outputs.already_in_pypi == 'false'
+    needs: [checks, release-github]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && needs.checks.outputs.already_in_pypi == 'false'
     steps:
       - uses: actions/checkout@v2
       - name: download GitHub artifacts
         run: |
           mkdir -p dist
           cd dist
-          curl -s https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ needs.testjob1.outputs.current_version }} \
+          curl -s https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ needs.checks.outputs.current_version }} \
             | jq -r ".assets[] | select(.name | contains(\"${{ env.PKG_NAME }}\")) | .browser_download_url" \
             | wget -i -
           ls

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: release
+
+on:
+  push:
+    branches: [ stable ]
+  workflow_dispatch:
+
+jobs:
+
+  checks:
+    name: check releases
+    runs-on: ubuntu-latest
+    outputs:
+      current_version: ${{ steps.current_version.outputs.current_version }}
+      version_latest: ${{ steps.version_latest.outputs.version_latest }}
+      already_released: ${{ steps.version_latest.outputs.version_latest == steps.current_version.outputs.current_version }}
+      already_in_pypi: ${{ steps.check_in_pypi.outputs.pypi_versions != '' }}
+    steps:
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get current version
+        id: current_version
+        run: |
+          python -m pip install . --no-deps
+          out="$(pip show ${{ env.PKG_NAME }} | grep Version: | cut -d'' '' -f 2)"
+          echo "$out"
+          echo "::set-output name=current_version::$out"
+        shell: bash
+      - name: Get latest tag
+        id: version_latest
+        run: |
+          out="$(git describe --abbrev=0 --tags | cut -d'v' -f 2)"
+          echo "$out"
+          echo "::set-output name=version_latest::$out"
+        shell: bash
+      - name: check if already deployed to PyPI
+        id: check_in_pypi
+        # Note. other options:
+        #   - use 'pip install --no-deps PKG==VERSION' with current version
+        #   - use 'pip index versions PKG==VERSION'
+        #     (but it's a kind of experimental feature of pip >= 21.2)
+        run: |
+          python -m pip install --upgrade pip
+          out="$(pip install --use-deprecated=legacy-resolver ${{ env.PKG_NAME }}== 2>&1 \
+              | grep -E "Could not find .* ${{ steps.current_version.outputs.current_version }}(,|\))")"
+          echo "::set-output name=pypi_versions::$out"
+        shell: bash {0}  # to opt-out of default fail-fast behavior
+
+  release-github:
+    name: GitHub Release
+    runs-on: ubuntu-latest
+    needs: testjob1
+    if: github.event_name == 'push' && github.ref == 'refs/heads/stable'
+    steps:
+      - uses: actions/checkout@v2
+      - name: build dist
+        if: needs.testjob1.outputs.already_released == 'false'
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade build
+          python -m build
+      - uses: ncipollo/release-action@v1
+        if: needs.testjob1.outputs.already_released == 'false'
+        with:
+          artifacts: "dist/*"
+          tag: v${{ needs.testjob1.outputs.current_version }}
+          commit: stable
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy-pypi:
+    name: Deploy to PyPI
+    runs-on: ubuntu-latest
+    needs: [testjob1, testjob4]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && needs.testjob1.outputs.already_in_pypi == 'false'
+    steps:
+      - uses: actions/checkout@v2
+      - name: download GitHub artifacts
+        run: |
+          mkdir -p dist
+          cd dist
+          curl -s https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ needs.testjob1.outputs.current_version }} \
+            | jq -r ".assets[] | select(.name | contains(\"${{ env.PKG_NAME }}\")) | .browser_download_url" \
+            | wget -i -
+          ls
+        shell: bash
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+            user: __token__
+            password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,15 +2,51 @@ name: tests
 
 on: [ pull_request ]
 
-jobs:
-  build:
 
+env:
+  PKG_NAME: peerdid
+
+
+jobs:
+
+  check-version-bumped:
+    name: Check version bumped
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Get current version
+        id: current_version
+        run: |
+          python -m pip install --upgrade pip
+          pip install . --no-deps
+          out="$(pip show ${{ env.PKG_NAME }} | grep Version: | cut -d'' '' -f 2)"
+          echo "$out"
+          echo "::set-output name=current_version::$out"
+        shell: bash
+      - name: Get latest tag
+        id: version_latest
+        run: |
+          out="$(git describe --abbrev=0 --tags | cut -d'v' -f 2)"
+          echo "$out"
+          echo "::set-output name=version_latest::$out"
+        shell: bash
+      - name: fail unless bumped
+        # TODO check if greater
+        if: steps.version_latest.outputs.version_latest == steps.current_version.outputs.current_version
+        run: exit 1
+
+  build:
     strategy:
       matrix:
         python-version: [ 3.5, 3.6, 3.7, 3.8, 3.9 ]
         os: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
-
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,11 +15,11 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'stable'
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+
       - uses: actions/setup-python@v2
         with:
           python-version: '3.x'
+
       - name: Get current version
         id: current_version
         run: |
@@ -29,16 +29,20 @@ jobs:
           echo "$out"
           echo "::set-output name=current_version::$out"
         shell: bash
-      - name: Get latest tag
-        id: version_latest
+
+      # TODO improve (DRY): copy-paste from release.yml
+      - name: Get release info
+        id: release_info
         run: |
-          out="$(git describe --abbrev=0 --tags | cut -d'v' -f 2)"
-          echo "$out"
-          echo "::set-output name=version_latest::$out"
+          release_info="$(curl -s https://api.github.com/repos/${{ github.repository }}/releases \
+              | jq '.[] | select(.name == "v${{ steps.current_version.outputs.current_version }}")')"
+          echo "::set-output name=release_info::$release_info"
+          echo "$release_info"
         shell: bash
-      - name: fail unless bumped
-        # TODO check if greater
-        if: steps.version_latest.outputs.version_latest == steps.current_version.outputs.current_version
+
+      - name: fail unless release not found
+        # TODO check if greater than latest tag / release (?)
+        if: steps.release_info.outputs.release_info
         run: exit 1
 
   build:
@@ -49,15 +53,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install pytest
           pip install -r requirements.txt
+
       - name: Test with pytest
         run: |
           pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
   check-version-bumped:
     name: Check version bumped
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
+    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'stable'
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ dmypy.json
 
 # vim files
 *.swp
+*.swo

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Pycharm files
 .idea
+
+# vim files
+*.swp


### PR DESCRIPTION
Implements logic of release flows as follows:

- PR to stable:
    - job: fail the pipeline unless the current version is different than the latest tag
        - _follow-up_: current version should be higher
- push to stable / manual re-run:
    - job: idempotence checks
        - GitHub latest release check: whether it is the same as the current version
        - whether PyPI release includes the current version
    - job: GitHub Release
        - if no release yet:
            - build locally
            - push with tag creation
    - job: PyPI release
        - if no PyPI release yet:
            - download distributive from GitHub releases
            - publish to PyPI