### PR TITLE
Fixes and JWK format support in resolved DID Doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Example of DID documents:
         "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
         "authentication": {
             "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
-            "type": "ED25519",
+            "type": "Ed25519VerificationKey2018",
             "controller": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
             "publicKeyBase58": "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
         }
@@ -60,7 +60,7 @@ Example of DID documents:
         "authentication": [
             {
                 "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
-                "type": "ED25519",
+                "type": "Ed25519VerificationKey2018",
                 "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=",
                 "publicKeyBase58": "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
             }
@@ -68,7 +68,7 @@ Example of DID documents:
         "keyAgreement": [
             {
                 "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=#6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud",
-                "type": "X25519",
+                "type": "X25519KeyAgreementKey2019",
                 "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=",
                 "publicKeyBase58": "DmgBSHMqaZiYqwNMEJJuxWzsGGC8jUYADrfSdBrC6L8s"
             }
@@ -93,6 +93,13 @@ Example of DID documents:
         ]
     }
 
+## Assumptions and limitations
+- Input keys are expected in `base58` format only
+- Only `X25519` keys are support for key agreement
+- Only `ED25519` keys are support for authentication
+- Verification materials in the resolved DID Doc can be either in JWK (`publicKeyJwk`), base58 (`publicKeyBase58`) or base58 in multibase (`publicKeyMultibase`) format. 
+
+
 ## How to contribute
 
 Pull requests are welcome!
@@ -106,3 +113,4 @@ pipeline is executed on all PRs before review and contributors are expected to a
 
 - Executes all unit tests from the pull request.
 - Analyzes code style using Flake8.
+

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Example of DID documents:
 ## Assumptions and limitations
 - Input keys are expected in `base58` format only
 - Only `X25519` keys are support for key agreement
-- Only `ED25519` keys are support for authentication
+- Only `Ed25519` keys are support for authentication
 - Verification materials in the resolved DID Doc can be either in JWK (`publicKeyJwk`), base58 (`publicKeyBase58`) or base58 in multibase (`publicKeyMultibase`) format. 
 
 

--- a/README.md
+++ b/README.md
@@ -48,56 +48,58 @@ Example of DID documents:
         "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
         "authentication": {
             "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
-            "type": "Ed25519VerificationKey2018",
+            "type": "Ed25519VerificationKey2020",
             "controller": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
-            "publicKeyBase58": "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
+            "publicKeyMultibase": "zByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
         }
     }
 
     # did_doc_algo_2
-    {
-        "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=",
-        "authentication": [
-            {
-                "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
-                "type": "Ed25519VerificationKey2018",
-                "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=",
-                "publicKeyBase58": "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
-            }
-        ],
-        "keyAgreement": [
-            {
-                "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=#6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud",
-                "type": "X25519KeyAgreementKey2019",
-                "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=",
-                "publicKeyBase58": "DmgBSHMqaZiYqwNMEJJuxWzsGGC8jUYADrfSdBrC6L8s"
-            }
-        ],
-        "service": [
-            {
-                "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=#didcommmessaging",
-                "type": "didcommmessaging",
-                "serviceEndpoint": "https://example.com/endpoint",
-                "routingKeys": [
-                    "did:example:somemediator#somekey"
-                ]
-            },
-            {
-                "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=#example",
-                "type": "example",
-                "serviceEndpoint": "https://example.com/endpoint2",
-                "routingKeys": [
-                    "did:example:somemediator#somekey2"
-                ]
-            }
-        ]
-    }
+        {
+           "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+           "authentication": [
+               {
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                   "type": "Ed25519VerificationKey2020",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+                   "publicKeyMultibase": "zByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
+               },
+               {
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg",
+                   "type": "Ed25519VerificationKey2020",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+                   "publicKeyMultibase": "z3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J"
+               }
+           ],
+           "keyAgreement": [
+               {
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+                   "type": "X25519KeyAgreementKey2020",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+                   "publicKeyMultibase": "zJhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr"
+               }
+           ],
+           "service": [
+               {
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#didcommmessaging-0",
+                   "type": "didcommmessaging",
+                   "serviceEndpoint": "https://example.com/endpoint",
+                   "routingKeys": [
+                       "did:example:somemediator#somekey"
+                   ]
+               }
+           ]
+       }
 
 ## Assumptions and limitations
 - Input keys are expected in `base58` format only
 - Only `X25519` keys are support for key agreement
 - Only `Ed25519` keys are support for authentication
-- Verification materials in the resolved DID Doc can be either in JWK (`publicKeyJwk`), base58 (`publicKeyBase58`) or base58 in multibase (`publicKeyMultibase`) format. 
+- Supported verification materials in the resolved DID DOC:
+  - [Default] 2020 verification materials (`Ed25519VerificationKey2020` and `X25519KeyAgreementKey2020`) with multibase base58 (`publicKeyMultibase`) public key encoding.
+  - JWK (`JsonWebKey2020`) using JWK (`publicKeyJwk`) public key encoding 
+  - 2018/2019 verification materials (`Ed25519VerificationKey2018` and `X25519KeyAgreementKey2019`) using base58 (`publicKeyBase58`) public key encoding. 
+ 
 
 
 ## How to contribute

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Example code:
         '''
             [
                 {
-                    "type": "didcommmessaging",
+                    "type": "DIDCommMessaging",
                     "serviceEndpoint": "https://example.com/endpoint",
                     "routingKeys": ["did:example:somemediator#somekey"]
                 },
@@ -82,7 +82,7 @@ Example of DID documents:
            "service": [
                {
                    "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=#didcommmessaging-0",
-                   "type": "didcommmessaging",
+                   "type": "DIDCommMessaging",
                    "serviceEndpoint": "https://example.com/endpoint",
                    "routingKeys": [
                        "did:example:somemediator#somekey"

--- a/README.md
+++ b/README.md
@@ -56,36 +56,39 @@ Example of DID documents:
 
     # did_doc_algo_2
         {
-           "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+           "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=",
            "authentication": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
                    "type": "Ed25519VerificationKey2020",
-                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=",
                    "publicKeyMultibase": "zByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
                },
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=#6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg",
                    "type": "Ed25519VerificationKey2020",
-                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=",
                    "publicKeyMultibase": "z3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J"
                }
            ],
            "keyAgreement": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=#6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
                    "type": "X25519KeyAgreementKey2020",
-                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=",
                    "publicKeyMultibase": "zJhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr"
                }
            ],
            "service": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#didcommmessaging-0",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=#didcommmessaging-0",
                    "type": "didcommmessaging",
                    "serviceEndpoint": "https://example.com/endpoint",
                    "routingKeys": [
                        "did:example:somemediator#somekey"
+                   ],
+                   "accept": [
+                        "didcomm/v2", "didcomm/aip2;env=rfc587"
                    ]
                }
            ]

--- a/peerdid/did_doc.py
+++ b/peerdid/did_doc.py
@@ -23,7 +23,9 @@ class VerificationMaterialTypeAuthentication(Enum):
         return [e.value for e in VerificationMaterialTypeAuthentication]
 
 
-VerificationMaterialType = Union[VerificationMaterialTypeAgreement, VerificationMaterialTypeAuthentication]
+VerificationMaterialType = Union[
+    VerificationMaterialTypeAgreement, VerificationMaterialTypeAuthentication
+]
 
 
 class PublicKeyField(Enum):
@@ -38,13 +40,12 @@ VerificationMaterial = NamedTuple(
         ("field", PublicKeyField),
         ("type", VerificationMaterialType),
         ("value", Union[str, Dict]),
-        ("encnumbasis", str)
+        ("encnumbasis", str),
     ],
 )
 
 
 class VerificationMethod:
-
     def __init__(self, ver_material: VerificationMaterial, did: str):
         self.ver_material = ver_material
         self.did = did
@@ -59,12 +60,14 @@ class VerificationMethod:
 
 
 class JWK_OKP:
-
     def __init__(self, ver_material_type: VerificationMaterialType, value: bytes):
         self.x = base64.urlsafe_b64encode(value).decode("utf-8")
         if ver_material_type == VerificationMaterialTypeAgreement.JSON_WEB_KEY_2020:
             self.crv = "X25519"
-        elif ver_material_type == VerificationMaterialTypeAuthentication.JSON_WEB_KEY_2020:
+        elif (
+            ver_material_type
+            == VerificationMaterialTypeAuthentication.JSON_WEB_KEY_2020
+        ):
             self.crv = "Ed25519"
         else:
             raise ValueError("Unsupported JWK type: " + ver_material_type.value)
@@ -78,12 +81,13 @@ class JWK_OKP:
 
 
 class DIDDoc:
-
-    def __init__(self,
-                 did: str,
-                 authentication: List[VerificationMethod],
-                 key_agreement: Optional[List[VerificationMethod]] = None,
-                 service: Optional[List[Dict]] = None):
+    def __init__(
+        self,
+        did: str,
+        authentication: List[VerificationMethod],
+        key_agreement: Optional[List[VerificationMethod]] = None,
+        service: Optional[List[Dict]] = None,
+    ):
         self.authentication = authentication
         self.did = did
         self.key_agreement = key_agreement

--- a/peerdid/did_doc.py
+++ b/peerdid/did_doc.py
@@ -1,0 +1,100 @@
+import base64
+from enum import Enum
+from typing import NamedTuple, Union, Dict, List, Optional
+
+
+class VerificationMaterialTypeAgreement(Enum):
+    JSON_WEB_KEY_2020 = "JsonWebKey2020"
+    X25519_KEY_AGREEMENT_KEY_2019 = "X25519KeyAgreementKey2019"
+    X25519_KEY_AGREEMENT_KEY_2020 = "X25519KeyAgreementKey2020"
+
+    @classmethod
+    def values(cls):
+        return [e.value for e in VerificationMaterialTypeAgreement]
+
+
+class VerificationMaterialTypeAuthentication(Enum):
+    JSON_WEB_KEY_2020 = "JsonWebKey2020"
+    ED25519_VERIFICATION_KEY_2018 = "Ed25519VerificationKey2018"
+    ED25519_VERIFICATION_KEY_2020 = "Ed25519VerificationKey2020"
+
+    @classmethod
+    def values(cls):
+        return [e.value for e in VerificationMaterialTypeAuthentication]
+
+
+VerificationMaterialType = Union[VerificationMaterialTypeAgreement, VerificationMaterialTypeAuthentication]
+
+
+class PublicKeyField(Enum):
+    BASE58 = "publicKeyBase58"
+    MULTIBASE = "publicKeyMultibase"
+    JWK = "publicKeyJwk"
+
+
+VerificationMaterial = NamedTuple(
+    "VerificationMaterial",
+    [
+        ("field", PublicKeyField),
+        ("type", VerificationMaterialType),
+        ("value", Union[str, Dict]),
+        ("encnumbasis", str)
+    ],
+)
+
+
+class VerificationMethod:
+
+    def __init__(self, ver_material: VerificationMaterial, did: str):
+        self.ver_material = ver_material
+        self.did = did
+
+    def to_dict(self):
+        return {
+            "id": self.did + "#" + self.ver_material.encnumbasis,
+            "type": self.ver_material.type.value,
+            "controller": self.did,
+            self.ver_material.field.value: self.ver_material.value,
+        }
+
+
+class JWK_OKP:
+
+    def __init__(self, ver_material_type: VerificationMaterialType, value: bytes):
+        self.x = base64.urlsafe_b64encode(value).decode("utf-8")
+        if ver_material_type == VerificationMaterialTypeAgreement.JSON_WEB_KEY_2020:
+            self.crv = "X25519"
+        elif ver_material_type == VerificationMaterialTypeAuthentication.JSON_WEB_KEY_2020:
+            self.crv = "Ed25519"
+        else:
+            raise ValueError("Unsupported JWK type: " + ver_material_type.value)
+
+    def to_dict(self):
+        return {
+            "kty": "OKP",
+            "crv": self.crv,
+            "x": self.x,
+        }
+
+
+class DIDDoc:
+
+    def __init__(self,
+                 did: str,
+                 authentication: List[VerificationMethod],
+                 key_agreement: Optional[List[VerificationMethod]] = None,
+                 service: Optional[List[Dict]] = None):
+        self.authentication = authentication
+        self.did = did
+        self.key_agreement = key_agreement
+        self.service = service
+
+    def to_dict(self):
+        res = {}
+        res["id"] = self.did
+        res["authentication"] = [a.to_dict() for a in self.authentication]
+        if self.key_agreement is not None:
+            res["keyAgreement"] = [ka.to_dict() for ka in self.key_agreement]
+        if self.service is not None:
+            res["service"] = self.service
+        return res

--- a/peerdid/peer_did.py
+++ b/peerdid/peer_did.py
@@ -2,13 +2,13 @@ import json
 import re
 from typing import List, Optional
 
+from peerdid.did_doc import VerificationMaterialTypeAuthentication, DIDDoc, VerificationMethod, \
+    VerificationMaterialTypeAgreement
 from peerdid.peer_did_utils import (
     _encode_service,
-    _create_encnumbasis,
-    _build_did_doc_numalgo_0,
-    _build_did_doc_numalgo_2,
     _check_key_correctly_encoded,
-    _is_json,
+    _is_json, Numalgo2Prefix, _decode_service, _create_multibase_encnumbasis,
+    _decode_multibase_encnumbasis,
 )
 from peerdid.types import (
     PEER_DID,
@@ -52,17 +52,17 @@ def create_peer_did_numalgo_0(inception_key: PublicKeyAuthentication) -> PEER_DI
             + ". Expected: PublicKeyAuthentication"
         )
     if not _check_key_correctly_encoded(
-        inception_key.encoded_value, inception_key.encoding_type
+            inception_key.encoded_value, inception_key.encoding_type
     ):
         raise ValueError("Inception key is not correctly encoded")
-    peer_did = "did:peer:0z" + _create_encnumbasis(inception_key)
-    return peer_did
+
+    return "did:peer:0" + _create_multibase_encnumbasis(inception_key)
 
 
 def create_peer_did_numalgo_2(
-    encryption_keys: List[PublicKeyAgreement],
-    signing_keys: List[PublicKeyAuthentication],
-    service: Optional[JSON],
+        encryption_keys: List[PublicKeyAgreement],
+        signing_keys: List[PublicKeyAuthentication],
+        service: Optional[JSON],
 ) -> PEER_DID:
     """
     Generates peer_did according to the second algorithm
@@ -109,32 +109,32 @@ def create_peer_did_numalgo_2(
         raise TypeError("Service is not JSON type") from exte
     except ValueError as exve:
         raise ValueError("Service is not valid JSON") from exve
+
+    enc_sep = "." + Numalgo2Prefix.KEY_AGREEMENT.value
+    auth_sep = "." + Numalgo2Prefix.AUTHENTICATION.value
     encryption_keys_str = (
-        ".Ez" + ".Ez".join(_create_encnumbasis(key) for key in encryption_keys)
+        enc_sep + enc_sep.join(_create_multibase_encnumbasis(key) for key in encryption_keys)
         if encryption_keys
         else ""
     )
-    signing_keys_str = (
-        ".Vz" + ".Vz".join(_create_encnumbasis(key) for key in signing_keys)
+    auth_keys_str = (
+        auth_sep + auth_sep.join(_create_multibase_encnumbasis(key) for key in signing_keys)
         if signing_keys
         else ""
     )
     service_str = _encode_service(service) if service else ""
 
-    peer_did = "did:peer:2" + encryption_keys_str + signing_keys_str + service_str
+    peer_did = "did:peer:2" + encryption_keys_str + auth_keys_str + service_str
     return peer_did
 
 
 def resolve_peer_did(
-    peer_did: PEER_DID,
-    version_id=None,
-    format: VerificationMaterialFormat = VerificationMaterialFormat.BASE58,
+        peer_did: PEER_DID,
+        format: VerificationMaterialFormat = VerificationMaterialFormat.BASE58,
 ) -> JSON:
     """
     Resolves did_doc from peer_did
     :param peer_did: peer_did to resolve
-    :param version_id: a specific version of a DID doc. If value is default, version of DID doc will be latest.
-        version_id is not used for now, as we support only static layer where did doc never changes
     :param format: the format of public keys in the DID DOC. Default format is base58.
     :raises ValueError: if peer_did parameter does not match peer_did spec
     :return: resolved did_doc as a JSON string
@@ -142,14 +142,61 @@ def resolve_peer_did(
     if not is_peer_did(peer_did):
         raise ValueError("Invalid Peer DID")
     if peer_did[9] == "0":
-        return json.dumps(
-            _build_did_doc_numalgo_0(peer_did=peer_did, format=format), indent=4
-        )
-    if peer_did[9] == "2":
-        return json.dumps(
-            _build_did_doc_numalgo_2(peer_did=peer_did, format=format), indent=4
-        )
+        did_doc_dict = _build_did_doc_numalgo_0(peer_did=peer_did, format=format)
+    else:
+        did_doc_dict = _build_did_doc_numalgo_2(peer_did=peer_did, format=format)
+    return json.dumps(did_doc_dict, indent=4)
 
+
+def _build_did_doc_numalgo_0(
+        peer_did: PEER_DID, format: VerificationMaterialFormat
+) -> dict:
+    verification_material = _decode_multibase_encnumbasis(peer_did[10:], format)
+    if not isinstance(verification_material.type, VerificationMaterialTypeAuthentication):
+        raise ValueError("Invalid key type (key agreement instead of authentication)")
+
+    did_doc = DIDDoc(
+        did=peer_did,
+        authentication=[VerificationMethod(verification_material, peer_did)]
+    )
+    return did_doc.to_dict()
+
+
+def _build_did_doc_numalgo_2(
+        peer_did: PEER_DID, format: VerificationMaterialFormat
+) -> dict:
+    keys = peer_did[11:]
+    keys = keys.split(".")
+    service = ""
+    authentication = []
+    key_agreement = []
+
+    for key in keys:
+        prefix = key[0]
+        if prefix == Numalgo2Prefix.SERVICE.value:
+            service = key[1:]
+        elif prefix == Numalgo2Prefix.AUTHENTICATION.value:
+            verification_material = _decode_multibase_encnumbasis(key[1:], format)
+            if not isinstance(verification_material.type, VerificationMaterialTypeAuthentication):
+                raise ValueError("Invalid key type (key agreement instead of authentication) of:  " + key)
+            authentication.append(VerificationMethod(verification_material, peer_did))
+        elif prefix == Numalgo2Prefix.KEY_AGREEMENT.value:
+            verification_material = _decode_multibase_encnumbasis(key[1:], format)
+            if not isinstance(verification_material.type, VerificationMaterialTypeAgreement):
+                raise ValueError("Invalid key type (authentication instead of key agreement) of:  " + key)
+            key_agreement.append(VerificationMethod(verification_material, peer_did))
+        else:
+            raise ValueError("Unkniwn prefix: " + prefix)
+    decoded_service = _decode_service(service, peer_did)
+
+    did_doc = DIDDoc(
+        did=peer_did,
+        authentication=authentication,
+        key_agreement=key_agreement,
+        service=decoded_service
+    )
+
+    return did_doc.to_dict()
 
 # the method is not needed for the static layer, because did_doc can be obtained from peer_did and vice versa.
 # But the method will be needed for dynamic layer support

--- a/peerdid/peer_did.py
+++ b/peerdid/peer_did.py
@@ -10,7 +10,13 @@ from peerdid.peer_did_utils import (
     _check_key_correctly_encoded,
     _is_json,
 )
-from peerdid.types import PEER_DID, PublicKeyAgreement, PublicKeyAuthentication, JSON
+from peerdid.types import (
+    PEER_DID,
+    PublicKeyAgreement,
+    PublicKeyAuthentication,
+    JSON,
+    VerificationMaterialFormat,
+)
 
 
 def is_peer_did(peer_did: PEER_DID) -> bool:
@@ -119,21 +125,30 @@ def create_peer_did_numalgo_2(
     return peer_did
 
 
-def resolve_peer_did(peer_did: PEER_DID, version_id=None) -> JSON:
+def resolve_peer_did(
+    peer_did: PEER_DID,
+    version_id=None,
+    format: VerificationMaterialFormat = VerificationMaterialFormat.BASE58,
+) -> JSON:
     """
     Resolves did_doc from peer_did
     :param peer_did: peer_did to resolve
     :param version_id: a specific version of a DID doc. If value is default, version of DID doc will be latest.
         version_id is not used for now, as we support only static layer where did doc never changes
+    :param format: the format of public keys in the DID DOC. Default format is base58.
     :raises ValueError: if peer_did parameter does not match peer_did spec
     :return: resolved did_doc as a JSON string
     """
     if not is_peer_did(peer_did):
         raise ValueError("Invalid Peer DID")
     if peer_did[9] == "0":
-        return json.dumps(_build_did_doc_numalgo_0(peer_did=peer_did), indent=4)
+        return json.dumps(
+            _build_did_doc_numalgo_0(peer_did=peer_did, format=format), indent=4
+        )
     if peer_did[9] == "2":
-        return json.dumps(_build_did_doc_numalgo_2(peer_did=peer_did), indent=4)
+        return json.dumps(
+            _build_did_doc_numalgo_2(peer_did=peer_did, format=format), indent=4
+        )
 
 
 # the method is not needed for the static layer, because did_doc can be obtained from peer_did and vice versa.

--- a/peerdid/peer_did.py
+++ b/peerdid/peer_did.py
@@ -22,7 +22,7 @@ from peerdid.types import (
     PublicKeyAgreement,
     PublicKeyAuthentication,
     JSON,
-    VerificationMaterialFormat,
+    DIDDocVerMaterialFormat,
 )
 
 
@@ -139,12 +139,12 @@ def create_peer_did_numalgo_2(
 
 def resolve_peer_did(
     peer_did: PEER_DID,
-    format: VerificationMaterialFormat = VerificationMaterialFormat.MULTIBASE,
+    format: DIDDocVerMaterialFormat = DIDDocVerMaterialFormat.MULTIBASE,
 ) -> JSON:
     """
     Resolves did_doc from peer_did
     :param peer_did: peer_did to resolve
-    :param format: the format of public keys in the DID DOC. Default format is base58.
+    :param format: the format of public keys in the DID DOC. Default format is multibase.
     :raises ValueError: if peer_did parameter does not match peer_did spec
     :return: resolved did_doc as a JSON string
     """
@@ -158,7 +158,7 @@ def resolve_peer_did(
 
 
 def _build_did_doc_numalgo_0(
-    peer_did: PEER_DID, format: VerificationMaterialFormat
+    peer_did: PEER_DID, format: DIDDocVerMaterialFormat
 ) -> dict:
     verification_material = _decode_multibase_encnumbasis(peer_did[10:], format)
     if not isinstance(
@@ -174,7 +174,7 @@ def _build_did_doc_numalgo_0(
 
 
 def _build_did_doc_numalgo_2(
-    peer_did: PEER_DID, format: VerificationMaterialFormat
+    peer_did: PEER_DID, format: DIDDocVerMaterialFormat
 ) -> dict:
     keys = peer_did[11:]
     keys = keys.split(".")

--- a/peerdid/peer_did.py
+++ b/peerdid/peer_did.py
@@ -2,12 +2,19 @@ import json
 import re
 from typing import List, Optional
 
-from peerdid.did_doc import VerificationMaterialTypeAuthentication, DIDDoc, VerificationMethod, \
-    VerificationMaterialTypeAgreement
+from peerdid.did_doc import (
+    VerificationMaterialTypeAuthentication,
+    DIDDoc,
+    VerificationMethod,
+    VerificationMaterialTypeAgreement,
+)
 from peerdid.peer_did_utils import (
     _encode_service,
     _check_key_correctly_encoded,
-    _is_json, Numalgo2Prefix, _decode_service, _create_multibase_encnumbasis,
+    _is_json,
+    Numalgo2Prefix,
+    _decode_service,
+    _create_multibase_encnumbasis,
     _decode_multibase_encnumbasis,
 )
 from peerdid.types import (
@@ -52,7 +59,7 @@ def create_peer_did_numalgo_0(inception_key: PublicKeyAuthentication) -> PEER_DI
             + ". Expected: PublicKeyAuthentication"
         )
     if not _check_key_correctly_encoded(
-            inception_key.encoded_value, inception_key.encoding_type
+        inception_key.encoded_value, inception_key.encoding_type
     ):
         raise ValueError("Inception key is not correctly encoded")
 
@@ -60,9 +67,9 @@ def create_peer_did_numalgo_0(inception_key: PublicKeyAuthentication) -> PEER_DI
 
 
 def create_peer_did_numalgo_2(
-        encryption_keys: List[PublicKeyAgreement],
-        signing_keys: List[PublicKeyAuthentication],
-        service: Optional[JSON],
+    encryption_keys: List[PublicKeyAgreement],
+    signing_keys: List[PublicKeyAuthentication],
+    service: Optional[JSON],
 ) -> PEER_DID:
     """
     Generates peer_did according to the second algorithm
@@ -113,12 +120,14 @@ def create_peer_did_numalgo_2(
     enc_sep = "." + Numalgo2Prefix.KEY_AGREEMENT.value
     auth_sep = "." + Numalgo2Prefix.AUTHENTICATION.value
     encryption_keys_str = (
-        enc_sep + enc_sep.join(_create_multibase_encnumbasis(key) for key in encryption_keys)
+        enc_sep
+        + enc_sep.join(_create_multibase_encnumbasis(key) for key in encryption_keys)
         if encryption_keys
         else ""
     )
     auth_keys_str = (
-        auth_sep + auth_sep.join(_create_multibase_encnumbasis(key) for key in signing_keys)
+        auth_sep
+        + auth_sep.join(_create_multibase_encnumbasis(key) for key in signing_keys)
         if signing_keys
         else ""
     )
@@ -129,8 +138,8 @@ def create_peer_did_numalgo_2(
 
 
 def resolve_peer_did(
-        peer_did: PEER_DID,
-        format: VerificationMaterialFormat = VerificationMaterialFormat.BASE58,
+    peer_did: PEER_DID,
+    format: VerificationMaterialFormat = VerificationMaterialFormat.MULTIBASE,
 ) -> JSON:
     """
     Resolves did_doc from peer_did
@@ -149,21 +158,23 @@ def resolve_peer_did(
 
 
 def _build_did_doc_numalgo_0(
-        peer_did: PEER_DID, format: VerificationMaterialFormat
+    peer_did: PEER_DID, format: VerificationMaterialFormat
 ) -> dict:
     verification_material = _decode_multibase_encnumbasis(peer_did[10:], format)
-    if not isinstance(verification_material.type, VerificationMaterialTypeAuthentication):
+    if not isinstance(
+        verification_material.type, VerificationMaterialTypeAuthentication
+    ):
         raise ValueError("Invalid key type (key agreement instead of authentication)")
 
     did_doc = DIDDoc(
         did=peer_did,
-        authentication=[VerificationMethod(verification_material, peer_did)]
+        authentication=[VerificationMethod(verification_material, peer_did)],
     )
     return did_doc.to_dict()
 
 
 def _build_did_doc_numalgo_2(
-        peer_did: PEER_DID, format: VerificationMaterialFormat
+    peer_did: PEER_DID, format: VerificationMaterialFormat
 ) -> dict:
     keys = peer_did[11:]
     keys = keys.split(".")
@@ -177,13 +188,23 @@ def _build_did_doc_numalgo_2(
             service = key[1:]
         elif prefix == Numalgo2Prefix.AUTHENTICATION.value:
             verification_material = _decode_multibase_encnumbasis(key[1:], format)
-            if not isinstance(verification_material.type, VerificationMaterialTypeAuthentication):
-                raise ValueError("Invalid key type (key agreement instead of authentication) of:  " + key)
+            if not isinstance(
+                verification_material.type, VerificationMaterialTypeAuthentication
+            ):
+                raise ValueError(
+                    "Invalid key type (key agreement instead of authentication) of:  "
+                    + key
+                )
             authentication.append(VerificationMethod(verification_material, peer_did))
         elif prefix == Numalgo2Prefix.KEY_AGREEMENT.value:
             verification_material = _decode_multibase_encnumbasis(key[1:], format)
-            if not isinstance(verification_material.type, VerificationMaterialTypeAgreement):
-                raise ValueError("Invalid key type (authentication instead of key agreement) of:  " + key)
+            if not isinstance(
+                verification_material.type, VerificationMaterialTypeAgreement
+            ):
+                raise ValueError(
+                    "Invalid key type (authentication instead of key agreement) of:  "
+                    + key
+                )
             key_agreement.append(VerificationMethod(verification_material, peer_did))
         else:
             raise ValueError("Unkniwn prefix: " + prefix)
@@ -193,10 +214,11 @@ def _build_did_doc_numalgo_2(
         did=peer_did,
         authentication=authentication,
         key_agreement=key_agreement,
-        service=decoded_service
+        service=decoded_service,
     )
 
     return did_doc.to_dict()
+
 
 # the method is not needed for the static layer, because did_doc can be obtained from peer_did and vice versa.
 # But the method will be needed for dynamic layer support

--- a/peerdid/peer_did_utils.py
+++ b/peerdid/peer_did_utils.py
@@ -52,7 +52,7 @@ def _encode_service(service: JSON) -> str:
         re.sub(r"[\n\t\s]*", "", service)
         .replace("type", "t")
         .replace("serviceEndpoint", "s")
-        .replace("didcommmessaging", "dm")
+        .replace("DIDCommMessaging", "dm")
         .replace("routingKeys", "r")
         .replace("accept", "a")
         .encode("utf-8")
@@ -86,8 +86,8 @@ def _decode_service(service: str, peer_did: PEER_DID) -> List[dict]:
         service = list_of_service_dict[i]
         if "t" not in service:
             raise ValueError("service doesn't contain a type")
-        service_type = service.pop("t").replace("dm", "didcommmessaging")
-        service["id"] = peer_did + "#" + service_type + "-" + str(i)
+        service_type = service.pop("t").replace("dm", "DIDCommMessaging")
+        service["id"] = peer_did + "#" + service_type.lower() + "-" + str(i)
         service["type"] = service_type
         if "s" in service:
             service["serviceEndpoint"] = service.pop("s")

--- a/peerdid/peer_did_utils.py
+++ b/peerdid/peer_did_utils.py
@@ -8,8 +8,13 @@ from typing import Union, List
 import base58
 import varint
 
-from peerdid.did_doc import VerificationMaterial, VerificationMaterialTypeAgreement, \
-    VerificationMaterialTypeAuthentication, PublicKeyField, JWK_OKP
+from peerdid.did_doc import (
+    VerificationMaterial,
+    VerificationMaterialTypeAgreement,
+    VerificationMaterialTypeAuthentication,
+    PublicKeyField,
+    JWK_OKP,
+)
 from peerdid.types import (
     JSON,
     PublicKeyAgreement,
@@ -43,13 +48,17 @@ def _encode_service(service: JSON) -> str:
     """
     service_to_encode = (
         re.sub(r"[\n\t\s]*", "", service)
-            .replace("type", "t")
-            .replace("serviceEndpoint", "s")
-            .replace("didcommmessaging", "dm")
-            .replace("routingKeys", "r")
-            .encode("utf-8")
+        .replace("type", "t")
+        .replace("serviceEndpoint", "s")
+        .replace("didcommmessaging", "dm")
+        .replace("routingKeys", "r")
+        .encode("utf-8")
     )
-    return "." + Numalgo2Prefix.SERVICE.value + base64.b64encode(service_to_encode).decode("utf-8")
+    return (
+        "."
+        + Numalgo2Prefix.SERVICE.value
+        + base64.b64encode(service_to_encode).decode("utf-8")
+    )
 
 
 def _decode_service(service: str, peer_did: PEER_DID) -> List[dict]:
@@ -80,7 +89,9 @@ def _decode_service(service: str, peer_did: PEER_DID) -> List[dict]:
     return list_of_service_dict
 
 
-def _create_multibase_encnumbasis(key: Union[PublicKeyAgreement, PublicKeyAuthentication]) -> str:
+def _create_multibase_encnumbasis(
+    key: Union[PublicKeyAgreement, PublicKeyAuthentication]
+) -> str:
     """
     Creates multibased encnumbasis according to Peer DID spec
     (https://identity.foundation/peer-did-method-spec/index.html#method-specific-identifier)
@@ -94,8 +105,8 @@ def _create_multibase_encnumbasis(key: Union[PublicKeyAgreement, PublicKeyAuthen
 
 
 def _decode_multibase_encnumbasis(
-        multibase: str,
-        ver_material_format: VerificationMaterialFormat,
+    multibase: str,
+    ver_material_format: VerificationMaterialFormat,
 ) -> VerificationMaterial:
     """
     Decodes multibased encnumbasis to a verification material for DID DOC
@@ -111,14 +122,16 @@ def _decode_multibase_encnumbasis(
     decoded_encnumbasis_without_prefix = _remove_prefix(decoded_encnumbasis)
 
     if ver_material_format == VerificationMaterialFormat.BASE58:
-        public_key_value = base58.b58encode(decoded_encnumbasis_without_prefix) \
-            .decode("utf-8")
+        public_key_value = base58.b58encode(decoded_encnumbasis_without_prefix).decode(
+            "utf-8"
+        )
         public_key_field = PublicKeyField.BASE58
         ver_material_type = __get_2018_2019_ver_material_type(decoded_encnumbasis)
 
     elif ver_material_format == VerificationMaterialFormat.MULTIBASE:
-        public_key_value = MultibasePrefix.BASE58.value + \
-                           base58.b58encode(decoded_encnumbasis_without_prefix).decode("utf-8")
+        public_key_value = MultibasePrefix.BASE58.value + base58.b58encode(
+            decoded_encnumbasis_without_prefix
+        ).decode("utf-8")
         public_key_field = PublicKeyField.MULTIBASE
         ver_material_type = __get_2020_ver_material_type(decoded_encnumbasis)
 
@@ -135,7 +148,7 @@ def _decode_multibase_encnumbasis(
         field=public_key_field,
         type=ver_material_type,
         value=public_key_value,
-        encnumbasis=encnumbasis
+        encnumbasis=encnumbasis,
     )
 
 
@@ -184,7 +197,7 @@ def _remove_prefix(data: bytes) -> bytes:
     """
     prefix_int = _extract_prefix(data)
     prefix = varint.encode(prefix_int)
-    return data[len(prefix):]
+    return data[len(prefix) :]
 
 
 def _extract_prefix(data: bytes) -> int:
@@ -201,7 +214,7 @@ def _extract_prefix(data: bytes) -> int:
 
 
 def _add_prefix(
-        key_type: Union[PublicKeyTypeAgreement, PublicKeyTypeAuthentication], data: bytes
+    key_type: Union[PublicKeyTypeAgreement, PublicKeyTypeAuthentication], data: bytes
 ) -> bytes:
     """
     Adds prefix to a data

--- a/peerdid/peer_did_utils.py
+++ b/peerdid/peer_did_utils.py
@@ -2,12 +2,14 @@ import base64
 import hashlib
 import json
 import re
-from collections import namedtuple
+from enum import Enum
 from typing import Union, List
 
 import base58
 import varint
 
+from peerdid.did_doc import VerificationMaterial, VerificationMaterialTypeAgreement, \
+    VerificationMaterialTypeAuthentication, PublicKeyField, JWK_OKP
 from peerdid.types import (
     JSON,
     PublicKeyAgreement,
@@ -17,10 +19,18 @@ from peerdid.types import (
     PEER_DID,
     EncodingType,
     VerificationMaterialFormat,
-    VerificationMaterialTypeAuthentication,
-    VerificationMaterialTypeAgreement,
     PublicKeyType,
 )
+
+
+class Numalgo2Prefix(Enum):
+    AUTHENTICATION = "V"
+    KEY_AGREEMENT = "E"
+    SERVICE = "S"
+
+
+class MultibasePrefix(Enum):
+    BASE58 = "z"
 
 
 def _encode_service(service: JSON) -> str:
@@ -33,16 +43,13 @@ def _encode_service(service: JSON) -> str:
     """
     service_to_encode = (
         re.sub(r"[\n\t\s]*", "", service)
-        .replace("type", "t")
-        .replace("serviceEndpoint", "s")
-        .replace("didcommmessaging", "dm")
-        .replace("routingKeys", "r")
-        .encode("utf-8")
+            .replace("type", "t")
+            .replace("serviceEndpoint", "s")
+            .replace("didcommmessaging", "dm")
+            .replace("routingKeys", "r")
+            .encode("utf-8")
     )
-    return ".S" + base64.b64encode(service_to_encode).decode("utf-8")
-
-
-VerificationMaterial = namedtuple("VerificationMaterial", "type, field, value")
+    return "." + Numalgo2Prefix.SERVICE.value + base64.b64encode(service_to_encode).decode("utf-8")
 
 
 def _decode_service(service: str, peer_did: PEER_DID) -> List[dict]:
@@ -73,91 +80,100 @@ def _decode_service(service: str, peer_did: PEER_DID) -> List[dict]:
     return list_of_service_dict
 
 
-def _create_encnumbasis(key: Union[PublicKeyAgreement, PublicKeyAuthentication]) -> str:
+def _create_multibase_encnumbasis(key: Union[PublicKeyAgreement, PublicKeyAuthentication]) -> str:
     """
-    Creates encnumbasis according to Peer DID spec
+    Creates multibased encnumbasis according to Peer DID spec
     (https://identity.foundation/peer-did-method-spec/index.html#method-specific-identifier)
     :param key: public key
-    :return: encnumbasis
+    :return: transform+encnumbasis
     """
     decoded_key = base58.b58decode(key.encoded_value)
     prefixed_decoded_key = _add_prefix(key.type, decoded_key)
     encnumbasis = base58.b58encode(prefixed_decoded_key)
-    return encnumbasis.decode("utf-8")
+    return MultibasePrefix.BASE58.value + encnumbasis.decode("utf-8")
 
 
-def _decode_encnumbasis(
-    encnumbasis: str,
-    peer_did: PEER_DID,
-    ver_material_format: VerificationMaterialFormat,
-) -> dict:
-    """
-    Decodes encnumbasis
-    :param encnumbasis: encnumbasis to decode
-    :param peer_did: peer_did which will be used as an ID
-    :param ver_material_format: the format of public keys in the DID DOC
-    :return: decoded encnumbasis
-    """
-    decoded_encnumbasis = base58.b58decode(encnumbasis)
-    ver_material = _get_verification_material(decoded_encnumbasis, ver_material_format)
-    return {
-        "id": peer_did + "#" + encnumbasis,
-        "type": ver_material.type,
-        "controller": peer_did,
-        ver_material.field: ver_material.value,
-    }
-
-
-def _get_verification_material(
-    decoded_encnumbasis: bytes, ver_material_format: VerificationMaterialFormat
+def _decode_multibase_encnumbasis(
+        multibase: str,
+        ver_material_format: VerificationMaterialFormat,
 ) -> VerificationMaterial:
-    type = _get_public_key_type(data=bytes(decoded_encnumbasis))
+    """
+    Decodes multibased encnumbasis to a verification material for DID DOC
+    :param multibase: transform+encnumbasis to decode
+    :param ver_material_format: the format of public keys in the DID DOC
+    :return: decoded encnumbasis as verification material for DID DOC
+    """
+    transform = multibase[0]
+    if not transform == MultibasePrefix.BASE58.value:
+        raise ValueError("Unsupported transform part of peer_did: " + transform)
+    encnumbasis = multibase[1:]
+    decoded_encnumbasis = base58.b58decode(encnumbasis)
     decoded_encnumbasis_without_prefix = _remove_prefix(decoded_encnumbasis)
 
     if ver_material_format == VerificationMaterialFormat.BASE58:
-        public_key_value = base58.b58encode(decoded_encnumbasis_without_prefix).decode(
-            "utf-8"
-        )
-        public_key_field = "publicKeyBase58"
-        if type == PublicKeyTypeAgreement.X25519:
-            public_key_type = "X25519KeyAgreementKey2019"
-        elif type == PublicKeyTypeAuthentication.ED25519:
-            public_key_type = "Ed25519VerificationKey2018"
-        else:
-            raise ValueError("Unknown public key type {}".format(type))
+        public_key_value = base58.b58encode(decoded_encnumbasis_without_prefix) \
+            .decode("utf-8")
+        public_key_field = PublicKeyField.BASE58
+        ver_material_type = __get_2018_2019_ver_material_type(decoded_encnumbasis)
 
     elif ver_material_format == VerificationMaterialFormat.MULTIBASE:
-        public_key_value = "z" + base58.b58encode(
-            decoded_encnumbasis_without_prefix
-        ).decode("utf-8")
-        public_key_field = "publicKeyMultibase"
-        if type == PublicKeyTypeAgreement.X25519:
-            public_key_type = "X25519KeyAgreementKey2019"
-        elif type == PublicKeyTypeAuthentication.ED25519:
-            public_key_type = "Ed25519VerificationKey2020"
-        else:
-            raise ValueError("Unknown public key type {}".format(type))
+        public_key_value = MultibasePrefix.BASE58.value + \
+                           base58.b58encode(decoded_encnumbasis_without_prefix).decode("utf-8")
+        public_key_field = PublicKeyField.MULTIBASE
+        ver_material_type = __get_2020_ver_material_type(decoded_encnumbasis)
 
     elif ver_material_format == VerificationMaterialFormat.JWK:
-        public_key_field = "publicKeyJwk"
-        public_key_type = "JsonWebKey2020"
-        if type == PublicKeyTypeAgreement.X25519 or PublicKeyTypeAuthentication.ED25519:
-            crv = "X25519" if type == PublicKeyTypeAgreement.X25519 else "Ed25519"
-            x = base64.urlsafe_b64encode(decoded_encnumbasis_without_prefix).decode(
-                "utf-8"
-            )
-            public_key_value = {
-                "kty": "OKP",
-                "crv": crv,
-                "x": x,
-            }
-        else:
-            raise ValueError("Unknown public key type {}".format(type))
+        public_key_field = PublicKeyField.JWK
+        ver_material_type = __get_jwk_ver_material_type(decoded_encnumbasis)
+        jwk = JWK_OKP(ver_material_type, decoded_encnumbasis_without_prefix)
+        public_key_value = jwk.to_dict()
 
     else:
         raise ValueError("Unknown format {}".format(ver_material_format))
 
-    return VerificationMaterial(public_key_type, public_key_field, public_key_value)
+    return VerificationMaterial(
+        field=public_key_field,
+        type=ver_material_type,
+        value=public_key_value,
+        encnumbasis=encnumbasis
+    )
+
+
+def __get_2018_2019_ver_material_type(decoded_encnumbasis):
+    public_key_type = __get_public_key_type(decoded_encnumbasis)
+    if public_key_type == PublicKeyTypeAgreement.X25519:
+        return VerificationMaterialTypeAgreement.X25519_KEY_AGREEMENT_KEY_2019
+    elif public_key_type == PublicKeyTypeAuthentication.ED25519:
+        return VerificationMaterialTypeAuthentication.ED25519_VERIFICATION_KEY_2018
+    raise ValueError("Unknown public key type {}".format(public_key_type))
+
+
+def __get_2020_ver_material_type(decoded_encnumbasis):
+    public_key_type = __get_public_key_type(decoded_encnumbasis)
+    if public_key_type == PublicKeyTypeAgreement.X25519:
+        return VerificationMaterialTypeAgreement.X25519_KEY_AGREEMENT_KEY_2020
+    elif public_key_type == PublicKeyTypeAuthentication.ED25519:
+        return VerificationMaterialTypeAuthentication.ED25519_VERIFICATION_KEY_2020
+    raise ValueError("Unknown public key type {}".format(public_key_type))
+
+
+def __get_jwk_ver_material_type(decoded_encnumbasis):
+    public_key_type = __get_public_key_type(decoded_encnumbasis)
+    if public_key_type == PublicKeyTypeAgreement.X25519:
+        return VerificationMaterialTypeAgreement.JSON_WEB_KEY_2020
+    elif public_key_type == PublicKeyTypeAuthentication.ED25519:
+        return VerificationMaterialTypeAuthentication.JSON_WEB_KEY_2020
+    raise ValueError("Unknown public key type {}".format(type))
+
+
+def __get_public_key_type(data: bytes) -> PublicKeyType:
+    prefix = _extract_prefix(data)
+    if prefix in set(item.value for item in PublicKeyTypeAuthentication):
+        return PublicKeyTypeAuthentication(prefix)
+    elif prefix in set(item.value for item in PublicKeyTypeAgreement):
+        return PublicKeyTypeAgreement(prefix)
+    else:
+        raise ValueError("Prefix {} not present in the lookup table".format(prefix))
 
 
 def _remove_prefix(data: bytes) -> bytes:
@@ -168,23 +184,7 @@ def _remove_prefix(data: bytes) -> bytes:
     """
     prefix_int = _extract_prefix(data)
     prefix = varint.encode(prefix_int)
-    return data[len(prefix) :]
-
-
-def _get_public_key_type(data: bytes) -> PublicKeyType:
-    """
-    Gets codec from data
-    :param data: prefixed data
-    :raises ValueError: if prefix is not supported
-    :return: codec name
-    """
-    prefix = _extract_prefix(data)
-    if prefix in set(item.value for item in PublicKeyTypeAuthentication):
-        return PublicKeyTypeAuthentication(prefix)
-    elif prefix in set(item.value for item in PublicKeyTypeAgreement):
-        return PublicKeyTypeAgreement(prefix)
-    else:
-        raise ValueError("Prefix {} not present in the lookup table".format(prefix))
+    return data[len(prefix):]
 
 
 def _extract_prefix(data: bytes) -> int:
@@ -201,7 +201,7 @@ def _extract_prefix(data: bytes) -> int:
 
 
 def _add_prefix(
-    key_type: Union[PublicKeyTypeAgreement, PublicKeyTypeAuthentication], data: bytes
+        key_type: Union[PublicKeyTypeAgreement, PublicKeyTypeAuthentication], data: bytes
 ) -> bytes:
     """
     Adds prefix to a data
@@ -220,84 +220,6 @@ def _encode_filename(filename: str) -> str:
     :return: encoded filename as SHA256 string
     """
     return hashlib.sha256(filename.encode()).hexdigest()
-
-
-def _build_did_doc_numalgo_0(
-    peer_did: PEER_DID, format: VerificationMaterialFormat
-) -> dict:
-    """
-    Helper method to create did_doc according to numalgo 0
-    :param peer_did: peer_did to resolve
-    :param format: the format of public keys in the DID DOC
-    :raises ValueError:
-        1) if peer_did contains encryption key instead of signing
-        2) if peer_did contains unsupported transform part
-    :return: did_doc
-    """
-    inception_key = peer_did[11:]
-    encoding_algorithm = peer_did[10]
-    if not encoding_algorithm == "z":
-        raise ValueError("Unsupported encoding algorithm of key: " + encoding_algorithm)
-    decoded_encnumbasis = _decode_encnumbasis(inception_key, peer_did, format)
-    if (
-        not decoded_encnumbasis["type"]
-        in VerificationMaterialTypeAuthentication.values()
-    ):
-        raise ValueError("Invalid key type (encryption instead of signing)")
-    did_doc = {"id": peer_did, "authentication": [decoded_encnumbasis]}
-    return did_doc
-
-
-def _build_did_doc_numalgo_2(
-    peer_did: PEER_DID, format: VerificationMaterialFormat
-) -> dict:
-    """
-    Helper method to create did_doc according to numalgo 2
-    :param peer_did: peer_did to resolve
-    :param format: the format of public keys in the DID DOC
-    :return: did_doc
-    """
-    keys = peer_did[11:]
-    keys = keys.split(".")
-    service = ""
-    keys_without_purpose_code = []
-    for key in keys:
-        if key[0] != "S":
-            transform = key[1]
-            if not transform == "z":
-                raise ValueError("Unsupported transform part of peer_did: " + transform)
-            keys_without_purpose_code.append(key[2:])
-        else:
-            service = key[1:]
-    decoded_encnumbasises = [
-        _decode_encnumbasis(key, peer_did, format) for key in keys_without_purpose_code
-    ]
-    decoded_service = _decode_service(service, peer_did)
-
-    authentication = []
-    key_agreement = []
-    for i in range(len(decoded_encnumbasises)):
-        if (
-            decoded_encnumbasises[i]["type"]
-            in VerificationMaterialTypeAuthentication.values()
-            and keys[i][0] == "V"
-        ):
-            authentication.append(decoded_encnumbasises[i])
-        elif (
-            decoded_encnumbasises[i]["type"]
-            in VerificationMaterialTypeAgreement.values()
-            and keys[i][0] == "E"
-        ):
-            key_agreement.append(decoded_encnumbasises[i])
-        else:
-            raise ValueError("Invalid key type of: " + keys[i])
-    did_doc = {
-        "id": peer_did,
-        "authentication": authentication,
-        "keyAgreement": key_agreement,
-        "service": decoded_service,
-    }
-    return did_doc
 
 
 def _check_key_correctly_encoded(key: str, encoding_type: EncodingType) -> bool:

--- a/peerdid/peer_did_utils.py
+++ b/peerdid/peer_did_utils.py
@@ -54,6 +54,7 @@ def _encode_service(service: JSON) -> str:
         .replace("serviceEndpoint", "s")
         .replace("didcommmessaging", "dm")
         .replace("routingKeys", "r")
+        .replace("accept", "a")
         .encode("utf-8")
     )
     return (
@@ -83,11 +84,17 @@ def _decode_service(service: str, peer_did: PEER_DID) -> List[dict]:
 
     for i in range(len(list_of_service_dict)):
         service = list_of_service_dict[i]
+        if "t" not in service:
+            raise ValueError("service doesn't contain a type")
         service_type = service.pop("t").replace("dm", "didcommmessaging")
         service["id"] = peer_did + "#" + service_type + "-" + str(i)
         service["type"] = service_type
-        service["serviceEndpoint"] = service.pop("s")
-        service["routingKeys"] = service.pop("r")
+        if "s" in service:
+            service["serviceEndpoint"] = service.pop("s")
+        if "r" in service:
+            service["routingKeys"] = service.pop("r")
+        if "a" in service:
+            service["accept"] = service.pop("a")
     return list_of_service_dict
 
 

--- a/peerdid/peer_did_utils.py
+++ b/peerdid/peer_did_utils.py
@@ -23,8 +23,7 @@ from peerdid.types import (
     PublicKeyTypeAuthentication,
     PEER_DID,
     EncodingType,
-    VerificationMaterialFormat,
-    PublicKeyType,
+    DIDDocVerMaterialFormat,
 )
 
 
@@ -36,6 +35,9 @@ class Numalgo2Prefix(Enum):
 
 class MultibasePrefix(Enum):
     BASE58 = "z"
+
+
+PublicKeyType = Union[PublicKeyTypeAgreement, PublicKeyTypeAuthentication]
 
 
 def _encode_service(service: JSON) -> str:
@@ -106,7 +108,7 @@ def _create_multibase_encnumbasis(
 
 def _decode_multibase_encnumbasis(
     multibase: str,
-    ver_material_format: VerificationMaterialFormat,
+    ver_material_format: DIDDocVerMaterialFormat,
 ) -> VerificationMaterial:
     """
     Decodes multibased encnumbasis to a verification material for DID DOC
@@ -121,21 +123,21 @@ def _decode_multibase_encnumbasis(
     decoded_encnumbasis = base58.b58decode(encnumbasis)
     decoded_encnumbasis_without_prefix = _remove_prefix(decoded_encnumbasis)
 
-    if ver_material_format == VerificationMaterialFormat.BASE58:
+    if ver_material_format == DIDDocVerMaterialFormat.BASE58:
         public_key_value = base58.b58encode(decoded_encnumbasis_without_prefix).decode(
             "utf-8"
         )
         public_key_field = PublicKeyField.BASE58
         ver_material_type = __get_2018_2019_ver_material_type(decoded_encnumbasis)
 
-    elif ver_material_format == VerificationMaterialFormat.MULTIBASE:
+    elif ver_material_format == DIDDocVerMaterialFormat.MULTIBASE:
         public_key_value = MultibasePrefix.BASE58.value + base58.b58encode(
             decoded_encnumbasis_without_prefix
         ).decode("utf-8")
         public_key_field = PublicKeyField.MULTIBASE
         ver_material_type = __get_2020_ver_material_type(decoded_encnumbasis)
 
-    elif ver_material_format == VerificationMaterialFormat.JWK:
+    elif ver_material_format == DIDDocVerMaterialFormat.JWK:
         public_key_field = PublicKeyField.JWK
         ver_material_type = __get_jwk_ver_material_type(decoded_encnumbasis)
         jwk = JWK_OKP(ver_material_type, decoded_encnumbasis_without_prefix)

--- a/peerdid/types.py
+++ b/peerdid/types.py
@@ -22,6 +22,7 @@ class VerificationMaterialFormat(Enum):
     BASE58 = 2
     MULTIBASE = 3
 
+
 PublicKeyAgreement = NamedTuple(
     "PublicKeyAgreement",
     [

--- a/peerdid/types.py
+++ b/peerdid/types.py
@@ -22,26 +22,6 @@ class VerificationMaterialFormat(Enum):
     BASE58 = 2
     MULTIBASE = 3
 
-
-class VerificationMaterialTypeAgreement(Enum):
-    JSON_WEB_KEY_2020 = "JsonWebKey2020"
-    X25519_KEY_AGREEMENT_KEY_2019 = "X25519KeyAgreementKey2019"
-
-    @staticmethod
-    def values():
-        return [e.value for e in VerificationMaterialTypeAgreement]
-
-
-class VerificationMaterialTypeAuthentication(Enum):
-    JSON_WEB_KEY_2020 = "JsonWebKey2020"
-    ED25519_VERIFICATION_KEY_2018 = "Ed25519VerificationKey2018"
-    ED25519_VERIFICATION_KEY_2020 = "Ed25519VerificationKey2020"
-
-    @staticmethod
-    def values():
-        return [e.value for e in VerificationMaterialTypeAuthentication]
-
-
 PublicKeyAgreement = NamedTuple(
     "PublicKeyAgreement",
     [

--- a/peerdid/types.py
+++ b/peerdid/types.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import NamedTuple, Union
+from typing import NamedTuple
 
 
 class PublicKeyTypeAgreement(Enum):
@@ -10,14 +10,11 @@ class PublicKeyTypeAuthentication(Enum):
     ED25519 = 0xED
 
 
-PublicKeyType = Union[PublicKeyTypeAgreement, PublicKeyTypeAuthentication]
-
-
 class EncodingType(Enum):
     BASE58 = 0
 
 
-class VerificationMaterialFormat(Enum):
+class DIDDocVerMaterialFormat(Enum):
     JWK = 1
     BASE58 = 2
     MULTIBASE = 3

--- a/peerdid/types.py
+++ b/peerdid/types.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import NamedTuple
+from typing import NamedTuple, Union
 
 
 class PublicKeyTypeAgreement(Enum):
@@ -8,11 +8,38 @@ class PublicKeyTypeAgreement(Enum):
 
 class PublicKeyTypeAuthentication(Enum):
     ED25519 = 0xED
-    SECP256K1 = 0xE7
+
+
+PublicKeyType = Union[PublicKeyTypeAgreement, PublicKeyTypeAuthentication]
 
 
 class EncodingType(Enum):
     BASE58 = 0
+
+
+class VerificationMaterialFormat(Enum):
+    JWK = 1
+    BASE58 = 2
+    MULTIBASE = 3
+
+
+class VerificationMaterialTypeAgreement(Enum):
+    JSON_WEB_KEY_2020 = "JsonWebKey2020"
+    X25519_KEY_AGREEMENT_KEY_2019 = "X25519KeyAgreementKey2019"
+
+    @staticmethod
+    def values():
+        return [e.value for e in VerificationMaterialTypeAgreement]
+
+
+class VerificationMaterialTypeAuthentication(Enum):
+    JSON_WEB_KEY_2020 = "JsonWebKey2020"
+    ED25519_VERIFICATION_KEY_2018 = "Ed25519VerificationKey2018"
+    ED25519_VERIFICATION_KEY_2020 = "Ed25519VerificationKey2020"
+
+    @staticmethod
+    def values():
+        return [e.value for e in VerificationMaterialTypeAuthentication]
 
 
 PublicKeyAgreement = NamedTuple(

--- a/tests/demo.py
+++ b/tests/demo.py
@@ -32,7 +32,7 @@ def test_create_save_resolve_peer_did():
     service = """
             [
                 {
-                    "type": "didcommmessaging",
+                    "type": "DIDCommMessaging",
                     "serviceEndpoint": "https://example.com/endpoint",
                     "routingKeys": ["did:example:somemediator#somekey"]
                 },

--- a/tests/test_create_peer_did_numalgo_2.py
+++ b/tests/test_create_peer_did_numalgo_2.py
@@ -31,7 +31,8 @@ VALID_SERVICE = """
     {
         "type": "didcommmessaging",
         "serviceEndpoint": "https://example.com/endpoint",
-        "routingKeys": ["did:example:somemediator#somekey"]
+        "routingKeys": ["did:example:somemediator#somekey"],
+        "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
     }
     """
 
@@ -49,9 +50,10 @@ def test_create_numalgo_2_positive():
                 "routingKeys": ["did:example:somemediator#somekey"]
             },
             {
-                "type": "didcommmessaging",
+                "type": "example",
                 "serviceEndpoint": "https://example.com/endpoint2",
-                "routingKeys": ["did:example:somemediator#somekey2"]
+                "routingKeys": ["did:example:somemediator#somekey2"],
+                "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
             }
             ]
             """
@@ -64,9 +66,7 @@ def test_create_numalgo_2_positive():
         == "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
         ".Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
         ".Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg"
-        ".SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlO"
-        "nNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9p"
-        "bnQyIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTIiXX1d"
+        ".SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0="
     )
     assert is_peer_did(peer_did_algo_2)
 
@@ -86,7 +86,7 @@ def test_create_numalgo_2_without_encryption_keys():
         peer_did_algo_2
         == "did:peer:2.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
         ".Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg"
-        ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0="
+        ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0="
     )
     assert is_peer_did(peer_did_algo_2)
 
@@ -102,7 +102,7 @@ def test_create_numalgo_2_without_signing_keys():
     assert (
         peer_did_algo_2
         == "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
-        ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0="
+        ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0="
     )
     assert is_peer_did(peer_did_algo_2)
 

--- a/tests/test_create_peer_did_numalgo_2.py
+++ b/tests/test_create_peer_did_numalgo_2.py
@@ -29,7 +29,7 @@ VALID_ED25519_KEY_2 = PublicKeyAuthentication(
 
 VALID_SERVICE = """
     {
-        "type": "didcommmessaging",
+        "type": "DIDCommMessaging",
         "serviceEndpoint": "https://example.com/endpoint",
         "routingKeys": ["did:example:somemediator#somekey"],
         "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
@@ -45,7 +45,7 @@ def test_create_numalgo_2_positive():
     ]
     service = """[
             {
-                "type": "didcommmessaging",
+                "type": "DIDCommMessaging",
                 "serviceEndpoint": "https://example.com/endpoint",
                 "routingKeys": ["did:example:somemediator#somekey"]
             },
@@ -287,7 +287,7 @@ def test_create_numalgo_2_service_has_more_fields_than_in_conversion_table():
         VALID_ED25519_KEY_2,
     ]
     service = """{
-        "type": "didcommmessaging",
+        "type": "DIDCommMessaging",
         "serviceEndpoint": "https://example.com/endpoint",
         "routingKeys": ["did:example:somemediator#somekey"],
         "example1": "myExample1",
@@ -388,7 +388,7 @@ def test_create_numalgo_2_malformed_encryption_key_not_base58_encoded():
         VALID_ED25519_KEY_2,
     ]
     service = """{
-            "type": "didcommmessaging",
+            "type": "DIDCommMessaging",
             "serviceEndpoint": "https://example.com/endpoint",
             "routingKeys": ["did:example:somemediator#somekey"]
             }
@@ -412,7 +412,7 @@ def test_create_numalgo_2_malformed_short_encryption_key():
         VALID_ED25519_KEY_2,
     ]
     service = """{
-            "type": "didcommmessaging",
+            "type": "DIDCommMessaging",
             "serviceEndpoint": "https://example.com/endpoint",
             "routingKeys": ["did:example:somemediator#somekey"]
             }
@@ -436,7 +436,7 @@ def test_create_numalgo_2_malformed_long_encryption_key():
         VALID_ED25519_KEY_2,
     ]
     service = """{
-            "type": "didcommmessaging",
+            "type": "DIDCommMessaging",
             "serviceEndpoint": "https://example.com/endpoint",
             "routingKeys": ["did:example:somemediator#somekey"]
             }
@@ -460,7 +460,7 @@ def test_create_numalgo_2_malformed_encryption_key_empty():
         VALID_ED25519_KEY_2,
     ]
     service = """{
-            "type": "didcommmessaging",
+            "type": "DIDCommMessaging",
             "serviceEndpoint": "https://example.com/endpoint",
             "routingKeys": ["did:example:somemediator#somekey"]
             }

--- a/tests/test_peer_did_utils.py
+++ b/tests/test_peer_did_utils.py
@@ -3,7 +3,6 @@ import pytest
 from peerdid.did_doc import (
     PublicKeyField,
     VerificationMaterial,
-    VerificationMaterialType,
     VerificationMaterialTypeAgreement,
     VerificationMaterialTypeAuthentication,
 )

--- a/tests/test_peer_did_utils.py
+++ b/tests/test_peer_did_utils.py
@@ -1,6 +1,13 @@
 import pytest
 
-from peerdid.peer_did_utils import _encode_service, _decode_encnumbasis
+from peerdid.did_doc import (
+    PublicKeyField,
+    VerificationMaterial,
+    VerificationMaterialType,
+    VerificationMaterialTypeAgreement,
+    VerificationMaterialTypeAuthentication,
+)
+from peerdid.peer_did_utils import _encode_service, _decode_multibase_encnumbasis
 from peerdid.types import VerificationMaterialFormat
 
 
@@ -55,86 +62,79 @@ def test_encode_service_with_multiple_entries_list():
     )
 
 
-PEER_DID = "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
-
-
 @pytest.mark.parametrize(
-    "test_value",
+    "input_multibase,format,expected",
     [
         (
-            "6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
-            "Ed25519VerificationKey2018",
-            "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
+            "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+            VerificationMaterialFormat.BASE58,
+            VerificationMaterial(
+                field=PublicKeyField.BASE58,
+                type=VerificationMaterialTypeAuthentication.ED25519_VERIFICATION_KEY_2018,
+                value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
+                encnumbasis="6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+            ),
         ),
         (
-            "6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
-            "X25519KeyAgreementKey2019",
-            "JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
+            "z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+            VerificationMaterialFormat.BASE58,
+            VerificationMaterial(
+                field=PublicKeyField.BASE58,
+                type=VerificationMaterialTypeAgreement.X25519_KEY_AGREEMENT_KEY_2019,
+                value="JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
+                encnumbasis="6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+            ),
+        ),
+        (
+            "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+            VerificationMaterialFormat.MULTIBASE,
+            VerificationMaterial(
+                field=PublicKeyField.MULTIBASE,
+                type=VerificationMaterialTypeAuthentication.ED25519_VERIFICATION_KEY_2020,
+                value="zByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
+                encnumbasis="6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+            ),
+        ),
+        (
+            "z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+            VerificationMaterialFormat.MULTIBASE,
+            VerificationMaterial(
+                field=PublicKeyField.MULTIBASE,
+                type=VerificationMaterialTypeAgreement.X25519_KEY_AGREEMENT_KEY_2020,
+                value="zJhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
+                encnumbasis="6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+            ),
+        ),
+        (
+            "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+            VerificationMaterialFormat.JWK,
+            VerificationMaterial(
+                field=PublicKeyField.JWK,
+                type=VerificationMaterialTypeAuthentication.JSON_WEB_KEY_2020,
+                value={
+                    "kty": "OKP",
+                    "crv": "Ed25519",
+                    "x": "owBhCbktDjkfS6PdQddT0D3yjSitaSysP3YimJ_YgmA=",
+                },
+                encnumbasis="6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+            ),
+        ),
+        (
+            "z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+            VerificationMaterialFormat.JWK,
+            VerificationMaterial(
+                field=PublicKeyField.JWK,
+                type=VerificationMaterialTypeAgreement.JSON_WEB_KEY_2020,
+                value={
+                    "kty": "OKP",
+                    "crv": "X25519",
+                    "x": "BIiFcQEn3dfvB2pjlhOQQour6jXy9d5s2FKEJNTOJik=",
+                },
+                encnumbasis="6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+            ),
         ),
     ],
 )
-def test_decode_encumbasis_base58(test_value):
-    enc_num_bassis = test_value[0]
-    res = _decode_encnumbasis(
-        enc_num_bassis, PEER_DID, VerificationMaterialFormat.BASE58
-    )
-    assert res["id"] == PEER_DID + "#" + enc_num_bassis
-    assert res["controller"] == PEER_DID
-    assert res["type"] == test_value[1]
-    assert "publicKeyBase58" in res
-    assert res["publicKeyBase58"] == test_value[2]
-
-
-@pytest.mark.parametrize(
-    "test_value",
-    [
-        (
-            "6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
-            "Ed25519VerificationKey2020",
-            "zByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
-        ),
-        (
-            "6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
-            "X25519KeyAgreementKey2019",
-            "zJhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
-        ),
-    ],
-)
-def test_decode_encumbasis_multibase(test_value):
-    enc_num_bassis = test_value[0]
-    res = _decode_encnumbasis(
-        enc_num_bassis, PEER_DID, VerificationMaterialFormat.MULTIBASE
-    )
-    assert res["id"] == PEER_DID + "#" + enc_num_bassis
-    assert res["controller"] == PEER_DID
-    assert res["type"] == test_value[1]
-    assert "publicKeyMultibase" in res
-    assert res["publicKeyMultibase"] == test_value[2]
-
-
-@pytest.mark.parametrize(
-    "test_value",
-    [
-        (
-            "6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
-            "Ed25519",
-            "owBhCbktDjkfS6PdQddT0D3yjSitaSysP3YimJ_YgmA=",
-        ),
-        (
-            "6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
-            "X25519",
-            "BIiFcQEn3dfvB2pjlhOQQour6jXy9d5s2FKEJNTOJik=",
-        ),
-    ],
-)
-def test_decode_encumbasis_jwk(test_value):
-    enc_num_bassis = test_value[0]
-    res = _decode_encnumbasis(enc_num_bassis, PEER_DID, VerificationMaterialFormat.JWK)
-    assert res["id"] == PEER_DID + "#" + enc_num_bassis
-    assert res["controller"] == PEER_DID
-    assert res["type"] == "JsonWebKey2020"
-    assert "publicKeyJwk" in res
-    jwk = res["publicKeyJwk"]
-    assert jwk["kty"] == "OKP"
-    assert jwk["crv"] == test_value[1]
-    assert jwk["x"] == test_value[2]
+def test_decode_encumbasis(input_multibase, format, expected):
+    res = _decode_multibase_encnumbasis(input_multibase, format)
+    assert res == expected

--- a/tests/test_peer_did_utils.py
+++ b/tests/test_peer_did_utils.py
@@ -6,34 +6,72 @@ from peerdid.did_doc import (
     VerificationMaterialTypeAgreement,
     VerificationMaterialTypeAuthentication,
 )
-from peerdid.peer_did_utils import _encode_service, _decode_multibase_encnumbasis
+from peerdid.peer_did_utils import (
+    _encode_service,
+    _decode_multibase_encnumbasis,
+    _decode_service,
+)
 from peerdid.types import DIDDocVerMaterialFormat
+from tests.test_vectors import PEER_DID_NUMALGO_2
 
 
 def test_encode_service():
     service = """{
         "type": "didcommmessaging",
         "serviceEndpoint": "https://example.com/endpoint",
-        "routingKeys": ["did:example:somemediator#somekey"]
+        "routingKeys": ["did:example:somemediator#somekey"],
+        "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
         }
         """
 
     assert (
         _encode_service(service)
-        == ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0="
+        == ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0="
     )
 
 
-def test_encode_service_without_routing_keys():
+def test_decode_service():
+    service = _decode_service(
+        service="eyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=",
+        peer_did=PEER_DID_NUMALGO_2,
+    )
+    expected = [
+        {
+            "id": PEER_DID_NUMALGO_2 + "#didcommmessaging-0",
+            "type": "didcommmessaging",
+            "serviceEndpoint": "https://example.com/endpoint",
+            "routingKeys": ["did:example:somemediator#somekey"],
+            "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"],
+        }
+    ]
+    assert service == expected
+
+
+def test_encode_service_minimal_fields():
     service = """{
         "type": "didcommmessaging",
-        "serviceEndpoint": "https://example.com/endpoint",
+        "serviceEndpoint": "https://example.com/endpoint"
         }
         """
     assert (
         _encode_service(service)
-        == ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsfQ=="
+        == ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9"
     )
+
+
+def test_decode_service_minimal_fields():
+    service = _decode_service(
+        service="eyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9",
+        peer_did=PEER_DID_NUMALGO_2,
+    )
+    expected = [
+        {
+            "id": PEER_DID_NUMALGO_2 + "#didcommmessaging-0",
+            "type": "didcommmessaging",
+            "serviceEndpoint": "https://example.com/endpoint",
+        }
+    ]
+    assert service == expected
 
 
 def test_encode_service_with_multiple_entries_list():
@@ -42,7 +80,8 @@ def test_encode_service_with_multiple_entries_list():
                 {
                     "type": "didcommmessaging",
                     "serviceEndpoint": "https://example.com/endpoint",
-                    "routingKeys": ["did:example:somemediator#somekey"]
+                    "routingKeys": ["did:example:somemediator#somekey"],
+                    "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
                 },
                 {
                     "type": "didcommmessaging",
@@ -55,9 +94,7 @@ def test_encode_service_with_multiple_entries_list():
     encoded_services = _encode_service(services)
     assert (
         encoded_services
-        == ".SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlO"
-        "nNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9p"
-        "bnQyIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTIiXX1d"
+        == ".SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19LHsidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQyIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTIiXX1d"
     )
 
 

--- a/tests/test_peer_did_utils.py
+++ b/tests/test_peer_did_utils.py
@@ -7,7 +7,7 @@ from peerdid.did_doc import (
     VerificationMaterialTypeAuthentication,
 )
 from peerdid.peer_did_utils import _encode_service, _decode_multibase_encnumbasis
-from peerdid.types import VerificationMaterialFormat
+from peerdid.types import DIDDocVerMaterialFormat
 
 
 def test_encode_service():
@@ -66,7 +66,7 @@ def test_encode_service_with_multiple_entries_list():
     [
         (
             "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
-            VerificationMaterialFormat.BASE58,
+            DIDDocVerMaterialFormat.BASE58,
             VerificationMaterial(
                 field=PublicKeyField.BASE58,
                 type=VerificationMaterialTypeAuthentication.ED25519_VERIFICATION_KEY_2018,
@@ -76,7 +76,7 @@ def test_encode_service_with_multiple_entries_list():
         ),
         (
             "z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
-            VerificationMaterialFormat.BASE58,
+            DIDDocVerMaterialFormat.BASE58,
             VerificationMaterial(
                 field=PublicKeyField.BASE58,
                 type=VerificationMaterialTypeAgreement.X25519_KEY_AGREEMENT_KEY_2019,
@@ -86,7 +86,7 @@ def test_encode_service_with_multiple_entries_list():
         ),
         (
             "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
-            VerificationMaterialFormat.MULTIBASE,
+            DIDDocVerMaterialFormat.MULTIBASE,
             VerificationMaterial(
                 field=PublicKeyField.MULTIBASE,
                 type=VerificationMaterialTypeAuthentication.ED25519_VERIFICATION_KEY_2020,
@@ -96,7 +96,7 @@ def test_encode_service_with_multiple_entries_list():
         ),
         (
             "z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
-            VerificationMaterialFormat.MULTIBASE,
+            DIDDocVerMaterialFormat.MULTIBASE,
             VerificationMaterial(
                 field=PublicKeyField.MULTIBASE,
                 type=VerificationMaterialTypeAgreement.X25519_KEY_AGREEMENT_KEY_2020,
@@ -106,7 +106,7 @@ def test_encode_service_with_multiple_entries_list():
         ),
         (
             "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
-            VerificationMaterialFormat.JWK,
+            DIDDocVerMaterialFormat.JWK,
             VerificationMaterial(
                 field=PublicKeyField.JWK,
                 type=VerificationMaterialTypeAuthentication.JSON_WEB_KEY_2020,
@@ -120,7 +120,7 @@ def test_encode_service_with_multiple_entries_list():
         ),
         (
             "z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
-            VerificationMaterialFormat.JWK,
+            DIDDocVerMaterialFormat.JWK,
             VerificationMaterial(
                 field=PublicKeyField.JWK,
                 type=VerificationMaterialTypeAgreement.JSON_WEB_KEY_2020,

--- a/tests/test_peer_did_utils.py
+++ b/tests/test_peer_did_utils.py
@@ -17,7 +17,7 @@ from tests.test_vectors import PEER_DID_NUMALGO_2
 
 def test_encode_service():
     service = """{
-        "type": "didcommmessaging",
+        "type": "DIDCommMessaging",
         "serviceEndpoint": "https://example.com/endpoint",
         "routingKeys": ["did:example:somemediator#somekey"],
         "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
@@ -38,7 +38,7 @@ def test_decode_service():
     expected = [
         {
             "id": PEER_DID_NUMALGO_2 + "#didcommmessaging-0",
-            "type": "didcommmessaging",
+            "type": "DIDCommMessaging",
             "serviceEndpoint": "https://example.com/endpoint",
             "routingKeys": ["did:example:somemediator#somekey"],
             "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"],
@@ -49,7 +49,7 @@ def test_decode_service():
 
 def test_encode_service_minimal_fields():
     service = """{
-        "type": "didcommmessaging",
+        "type": "DIDCommMessaging",
         "serviceEndpoint": "https://example.com/endpoint"
         }
         """
@@ -67,7 +67,7 @@ def test_decode_service_minimal_fields():
     expected = [
         {
             "id": PEER_DID_NUMALGO_2 + "#didcommmessaging-0",
-            "type": "didcommmessaging",
+            "type": "DIDCommMessaging",
             "serviceEndpoint": "https://example.com/endpoint",
         }
     ]
@@ -78,13 +78,13 @@ def test_encode_service_with_multiple_entries_list():
     services = """
             [
                 {
-                    "type": "didcommmessaging",
+                    "type": "DIDCommMessaging",
                     "serviceEndpoint": "https://example.com/endpoint",
                     "routingKeys": ["did:example:somemediator#somekey"],
                     "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
                 },
                 {
-                    "type": "didcommmessaging",
+                    "type": "DIDCommMessaging",
                     "serviceEndpoint": "https://example.com/endpoint2",
                     "routingKeys": ["did:example:somemediator#somekey2"]
                 }

--- a/tests/test_peer_did_utils.py
+++ b/tests/test_peer_did_utils.py
@@ -1,4 +1,7 @@
-from peerdid.peer_did_utils import _encode_service
+import pytest
+
+from peerdid.peer_did_utils import _encode_service, _decode_encnumbasis
+from peerdid.types import VerificationMaterialFormat
 
 
 def test_encode_service():
@@ -50,3 +53,88 @@ def test_encode_service_with_multiple_entries_list():
         "nNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9p"
         "bnQyIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTIiXX1d"
     )
+
+
+PEER_DID = "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+
+
+@pytest.mark.parametrize(
+    "test_value",
+    [
+        (
+            "6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+            "Ed25519VerificationKey2018",
+            "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
+        ),
+        (
+            "6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+            "X25519KeyAgreementKey2019",
+            "JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
+        ),
+    ],
+)
+def test_decode_encumbasis_base58(test_value):
+    enc_num_bassis = test_value[0]
+    res = _decode_encnumbasis(
+        enc_num_bassis, PEER_DID, VerificationMaterialFormat.BASE58
+    )
+    assert res["id"] == PEER_DID + "#" + enc_num_bassis
+    assert res["controller"] == PEER_DID
+    assert res["type"] == test_value[1]
+    assert "publicKeyBase58" in res
+    assert res["publicKeyBase58"] == test_value[2]
+
+
+@pytest.mark.parametrize(
+    "test_value",
+    [
+        (
+            "6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+            "Ed25519VerificationKey2020",
+            "zByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
+        ),
+        (
+            "6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+            "X25519KeyAgreementKey2019",
+            "zJhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr",
+        ),
+    ],
+)
+def test_decode_encumbasis_multibase(test_value):
+    enc_num_bassis = test_value[0]
+    res = _decode_encnumbasis(
+        enc_num_bassis, PEER_DID, VerificationMaterialFormat.MULTIBASE
+    )
+    assert res["id"] == PEER_DID + "#" + enc_num_bassis
+    assert res["controller"] == PEER_DID
+    assert res["type"] == test_value[1]
+    assert "publicKeyMultibase" in res
+    assert res["publicKeyMultibase"] == test_value[2]
+
+
+@pytest.mark.parametrize(
+    "test_value",
+    [
+        (
+            "6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+            "Ed25519",
+            "owBhCbktDjkfS6PdQddT0D3yjSitaSysP3YimJ_YgmA=",
+        ),
+        (
+            "6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+            "X25519",
+            "BIiFcQEn3dfvB2pjlhOQQour6jXy9d5s2FKEJNTOJik=",
+        ),
+    ],
+)
+def test_decode_encumbasis_jwk(test_value):
+    enc_num_bassis = test_value[0]
+    res = _decode_encnumbasis(enc_num_bassis, PEER_DID, VerificationMaterialFormat.JWK)
+    assert res["id"] == PEER_DID + "#" + enc_num_bassis
+    assert res["controller"] == PEER_DID
+    assert res["type"] == "JsonWebKey2020"
+    assert "publicKeyJwk" in res
+    jwk = res["publicKeyJwk"]
+    assert jwk["kty"] == "OKP"
+    assert jwk["crv"] == test_value[1]
+    assert jwk["x"] == test_value[2]

--- a/tests/test_resolve_peer_did_numalgo_0.py
+++ b/tests/test_resolve_peer_did_numalgo_0.py
@@ -14,7 +14,7 @@ from tests.test_vectors import (
 
 def test_resolve_positive_default():
     did_doc = resolve_peer_did(peer_did=PEER_DID_NUMALGO_0)
-    assert json.loads(did_doc) == json.loads(DID_DOC_NUMALGO_O_BASE58)
+    assert json.loads(did_doc) == json.loads(DID_DOC_NUMALGO_O_MULTIBASE)
 
 
 def test_resolve_positive_base58():

--- a/tests/test_resolve_peer_did_numalgo_0.py
+++ b/tests/test_resolve_peer_did_numalgo_0.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from peerdid.peer_did import resolve_peer_did
-from peerdid.types import VerificationMaterialFormat
+from peerdid.types import DIDDocVerMaterialFormat
 from tests.test_vectors import (
     PEER_DID_NUMALGO_0,
     DID_DOC_NUMALGO_O_BASE58,
@@ -19,21 +19,21 @@ def test_resolve_positive_default():
 
 def test_resolve_positive_base58():
     did_doc = resolve_peer_did(
-        peer_did=PEER_DID_NUMALGO_0, format=VerificationMaterialFormat.BASE58
+        peer_did=PEER_DID_NUMALGO_0, format=DIDDocVerMaterialFormat.BASE58
     )
     assert json.loads(did_doc) == json.loads(DID_DOC_NUMALGO_O_BASE58)
 
 
 def test_resolve_positive_multibase():
     did_doc = resolve_peer_did(
-        peer_did=PEER_DID_NUMALGO_0, format=VerificationMaterialFormat.MULTIBASE
+        peer_did=PEER_DID_NUMALGO_0, format=DIDDocVerMaterialFormat.MULTIBASE
     )
     assert json.loads(did_doc) == json.loads(DID_DOC_NUMALGO_O_MULTIBASE)
 
 
 def test_resolve_positive_jwk():
     did_doc = resolve_peer_did(
-        peer_did=PEER_DID_NUMALGO_0, format=VerificationMaterialFormat.JWK
+        peer_did=PEER_DID_NUMALGO_0, format=DIDDocVerMaterialFormat.JWK
     )
     assert json.loads(did_doc) == json.loads(DID_DOC_NUMALGO_O_JWK)
 

--- a/tests/test_resolve_peer_did_numalgo_0.py
+++ b/tests/test_resolve_peer_did_numalgo_0.py
@@ -3,29 +3,39 @@ import json
 import pytest
 
 from peerdid.peer_did import resolve_peer_did
+from peerdid.types import VerificationMaterialFormat
+from tests.test_vectors import (
+    PEER_DID_NUMALGO_0,
+    DID_DOC_NUMALGO_O_BASE58,
+    DID_DOC_NUMALGO_O_MULTIBASE,
+    DID_DOC_NUMALGO_O_JWK,
+)
 
 
-def test_resolve_positive():
-    expected_value = json.loads(
-        """
-           {
-               "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
-               "authentication": {
-                   "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
-                   "type": "ED25519",
-                   "controller": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
-                   "publicKeyBase58": "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
-               }
-           }
-        """
+def test_resolve_positive_default():
+    did_doc = resolve_peer_did(peer_did=PEER_DID_NUMALGO_0)
+    assert json.loads(did_doc) == json.loads(DID_DOC_NUMALGO_O_BASE58)
+
+
+def test_resolve_positive_base58():
+    did_doc = resolve_peer_did(
+        peer_did=PEER_DID_NUMALGO_0, format=VerificationMaterialFormat.BASE58
     )
+    assert json.loads(did_doc) == json.loads(DID_DOC_NUMALGO_O_BASE58)
 
-    real_value = json.loads(
-        resolve_peer_did(
-            peer_did="did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
-        )
+
+def test_resolve_positive_multibase():
+    did_doc = resolve_peer_did(
+        peer_did=PEER_DID_NUMALGO_0, format=VerificationMaterialFormat.MULTIBASE
     )
-    assert real_value == expected_value
+    assert json.loads(did_doc) == json.loads(DID_DOC_NUMALGO_O_MULTIBASE)
+
+
+def test_resolve_positive_jwk():
+    did_doc = resolve_peer_did(
+        peer_did=PEER_DID_NUMALGO_0, format=VerificationMaterialFormat.JWK
+    )
+    assert json.loads(did_doc) == json.loads(DID_DOC_NUMALGO_O_JWK)
 
 
 def test_resolve_unsupported_did_method():

--- a/tests/test_resolve_peer_did_numalgo_2.py
+++ b/tests/test_resolve_peer_did_numalgo_2.py
@@ -115,3 +115,13 @@ def test_resolve_numalgo_2_malformed_service_encoding():
             ".Va6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
             ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9\\GxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0="
         )
+
+
+def test_resolve_numalgo_2_invalid_prefix():
+    with pytest.raises(ValueError):
+        resolve_peer_did(
+            "did:peer:2"
+            ".Cz6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
+            ".Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg"
+            ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0="
+        )

--- a/tests/test_resolve_peer_did_numalgo_2.py
+++ b/tests/test_resolve_peer_did_numalgo_2.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from peerdid.peer_did import resolve_peer_did
-from peerdid.types import VerificationMaterialFormat
+from peerdid.types import DIDDocVerMaterialFormat
 from tests.test_vectors import (
     DID_DOC_NUMALGO_2_BASE58,
     PEER_DID_NUMALGO_2,
@@ -21,21 +21,21 @@ def test_resolve_numalgo_2_positive_default():
 
 def test_resolve_numalgo_2_positive_base58():
     did_doc = resolve_peer_did(
-        peer_did=PEER_DID_NUMALGO_2, format=VerificationMaterialFormat.BASE58
+        peer_did=PEER_DID_NUMALGO_2, format=DIDDocVerMaterialFormat.BASE58
     )
     assert json.loads(did_doc) == json.loads(DID_DOC_NUMALGO_2_BASE58)
 
 
 def test_resolve_numalgo_2_positive_multibase():
     did_doc = resolve_peer_did(
-        peer_did=PEER_DID_NUMALGO_2, format=VerificationMaterialFormat.MULTIBASE
+        peer_did=PEER_DID_NUMALGO_2, format=DIDDocVerMaterialFormat.MULTIBASE
     )
     assert json.loads(did_doc) == json.loads(DID_DOC_NUMALGO_2_MULTIBASE)
 
 
 def test_resolve_numalgo_2_positive_jwk():
     did_doc = resolve_peer_did(
-        peer_did=PEER_DID_NUMALGO_2, format=VerificationMaterialFormat.JWK
+        peer_did=PEER_DID_NUMALGO_2, format=DIDDocVerMaterialFormat.JWK
     )
     assert json.loads(did_doc) == json.loads(DID_DOC_NUMALGO_2_JWK)
 

--- a/tests/test_resolve_peer_did_numalgo_2.py
+++ b/tests/test_resolve_peer_did_numalgo_2.py
@@ -3,6 +3,46 @@ import json
 import pytest
 
 from peerdid.peer_did import resolve_peer_did
+from peerdid.types import VerificationMaterialFormat
+from tests.test_vectors import (
+    DID_DOC_NUMALGO_2_BASE58,
+    PEER_DID_NUMALGO_2,
+    DID_DOC_NUMALGO_2_MULTIBASE,
+    DID_DOC_NUMALGO_2_JWK,
+    DID_DOC_NUMALGO_2_BASE58_2_SERVICES,
+    PEER_DID_NUMALGO_2_2_SERVICES,
+)
+
+
+def test_resolve_numalgo_2_positive_default():
+    did_doc = resolve_peer_did(peer_did=PEER_DID_NUMALGO_2)
+    assert json.loads(did_doc) == json.loads(DID_DOC_NUMALGO_2_BASE58)
+
+
+def test_resolve_numalgo_2_positive_base58():
+    did_doc = resolve_peer_did(
+        peer_did=PEER_DID_NUMALGO_2, format=VerificationMaterialFormat.BASE58
+    )
+    assert json.loads(did_doc) == json.loads(DID_DOC_NUMALGO_2_BASE58)
+
+
+def test_resolve_numalgo_2_positive_multibase():
+    did_doc = resolve_peer_did(
+        peer_did=PEER_DID_NUMALGO_2, format=VerificationMaterialFormat.MULTIBASE
+    )
+    assert json.loads(did_doc) == json.loads(DID_DOC_NUMALGO_2_MULTIBASE)
+
+
+def test_resolve_numalgo_2_positive_jwk():
+    did_doc = resolve_peer_did(
+        peer_did=PEER_DID_NUMALGO_2, format=VerificationMaterialFormat.JWK
+    )
+    assert json.loads(did_doc) == json.loads(DID_DOC_NUMALGO_2_JWK)
+
+
+def test_resolve_numalgo_2_positive_service_is_2_element_array():
+    did_doc = resolve_peer_did(PEER_DID_NUMALGO_2_2_SERVICES)
+    assert json.loads(did_doc) == json.loads(DID_DOC_NUMALGO_2_BASE58_2_SERVICES)
 
 
 def test_resolve_numalgo_2_unsupported_transform_code():
@@ -75,111 +115,3 @@ def test_resolve_numalgo_2_malformed_service_encoding():
             ".Va6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
             ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9\\GxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0="
         )
-
-
-def test_resolve_numalgo_2_positive_service_is_1_element_array():
-    expected_value = json.loads(
-        """
-        {
-           "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
-           "authentication": [
-               {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
-                   "type": "ED25519",
-                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
-                   "publicKeyBase58": "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
-               },
-               {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg",
-                   "type": "ED25519",
-                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
-                   "publicKeyBase58": "3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J"
-               }
-           ],
-           "keyAgreement": [
-               {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
-                   "type": "X25519",
-                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
-                   "publicKeyBase58": "JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr"
-               }
-           ],
-           "service": [
-               {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#didcommmessaging-0",
-                   "type": "didcommmessaging",
-                   "serviceEndpoint": "https://example.com/endpoint",
-                   "routingKeys": [
-                       "did:example:somemediator#somekey"
-                   ]
-               }
-           ]
-       }
-       """
-    )
-
-    real_value = json.loads(
-        resolve_peer_did(
-            "did:peer:2"
-            ".Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
-            ".Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
-            ".Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg"
-            ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0="
-        )
-    )
-    assert real_value == expected_value
-
-
-def test_resolve_numalgo_2_positive_service_is_2_element_array():
-    expected_value = json.loads(
-        """
-    {
-        "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=",
-        "authentication": [
-            {
-                "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
-                "type": "ED25519",
-                "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=",
-                "publicKeyBase58": "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
-            }
-        ],
-        "keyAgreement": [
-            {
-                "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=#6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud",
-                "type": "X25519",
-                "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=",
-                "publicKeyBase58": "DmgBSHMqaZiYqwNMEJJuxWzsGGC8jUYADrfSdBrC6L8s"
-            }
-        ],
-        "service": [
-            {
-                "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=#didcommmessaging-0",
-                "type": "didcommmessaging",
-                "serviceEndpoint": "https://example.com/endpoint",
-                "routingKeys": [
-                    "did:example:somemediator#somekey"
-                ]
-            },
-            {
-                "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=#example-1",
-                "type": "example",
-                "serviceEndpoint": "https://example.com/endpoint2",
-                "routingKeys": [
-                    "did:example:somemediator#somekey2"
-                ]
-            }
-        ]
-    }
-    """
-    )
-
-    real_value = json.loads(
-        resolve_peer_did(
-            "did:peer:2"
-            ".Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud"
-            ".Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
-            ".SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0="
-        )
-    )
-
-    assert real_value == expected_value

--- a/tests/test_resolve_peer_did_numalgo_2.py
+++ b/tests/test_resolve_peer_did_numalgo_2.py
@@ -16,7 +16,7 @@ from tests.test_vectors import (
 
 def test_resolve_numalgo_2_positive_default():
     did_doc = resolve_peer_did(peer_did=PEER_DID_NUMALGO_2)
-    assert json.loads(did_doc) == json.loads(DID_DOC_NUMALGO_2_BASE58)
+    assert json.loads(did_doc) == json.loads(DID_DOC_NUMALGO_2_MULTIBASE)
 
 
 def test_resolve_numalgo_2_positive_base58():

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -82,7 +82,7 @@ DID_DOC_NUMALGO_2_BASE58 = """
            "service": [
                {
                    "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=#didcommmessaging-0",
-                   "type": "didcommmessaging",
+                   "type": "DIDCommMessaging",
                    "serviceEndpoint": "https://example.com/endpoint",
                    "routingKeys": [
                        "did:example:somemediator#somekey"
@@ -123,7 +123,7 @@ DID_DOC_NUMALGO_2_MULTIBASE = """
            "service": [
                {
                    "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=#didcommmessaging-0",
-                   "type": "didcommmessaging",
+                   "type": "DIDCommMessaging",
                    "serviceEndpoint": "https://example.com/endpoint",
                    "routingKeys": [
                        "did:example:somemediator#somekey"
@@ -176,7 +176,7 @@ DID_DOC_NUMALGO_2_JWK = """
            "service": [
                {
                    "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=#didcommmessaging-0",
-                   "type": "didcommmessaging",
+                   "type": "DIDCommMessaging",
                    "serviceEndpoint": "https://example.com/endpoint",
                    "routingKeys": [
                        "did:example:somemediator#somekey"
@@ -218,7 +218,7 @@ DID_DOC_NUMALGO_2_BASE58_2_SERVICES = """
             "service": [
                 {
                     "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0=#didcommmessaging-0",
-                    "type": "didcommmessaging",
+                    "type": "DIDCommMessaging",
                     "serviceEndpoint": "https://example.com/endpoint",
                     "routingKeys": [
                         "did:example:somemediator#somekey"

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -37,10 +37,10 @@ DID_DOC_NUMALGO_O_JWK = """
                     "type": "JsonWebKey2020",
                     "controller": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
                     "publicKeyJwk": {
-                         "kty": "OKP",                       
-                         "crv": "Ed25519",
-                         "x": "owBhCbktDjkfS6PdQddT0D3yjSitaSysP3YimJ_YgmA="
-                     }
+                        "kty": "OKP",
+                        "crv": "Ed25519",
+                        "x": "owBhCbktDjkfS6PdQddT0D3yjSitaSysP3YimJ_YgmA="
+                    }
                 }
             ]
         }
@@ -139,7 +139,7 @@ DID_DOC_NUMALGO_2_JWK = """
                    "type": "JsonWebKey2020",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
                     "publicKeyJwk": {
-                         "kty": "OKP",                       
+                         "kty": "OKP",
                          "crv": "Ed25519",
                          "x": "owBhCbktDjkfS6PdQddT0D3yjSitaSysP3YimJ_YgmA="
                      }
@@ -149,7 +149,7 @@ DID_DOC_NUMALGO_2_JWK = """
                    "type": "JsonWebKey2020",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
                     "publicKeyJwk": {
-                         "kty": "OKP",                       
+                         "kty": "OKP",
                          "crv": "Ed25519",
                          "x": "Itv8B__b1-Jos3LCpUe8EdTFGTCa_Dza6_3848P3R70="
                      }
@@ -161,7 +161,7 @@ DID_DOC_NUMALGO_2_JWK = """
                    "type": "JsonWebKey2020",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
                     "publicKeyJwk": {
-                         "kty": "OKP",                       
+                         "kty": "OKP",
                          "crv": "X25519",
                          "x": "BIiFcQEn3dfvB2pjlhOQQour6jXy9d5s2FKEJNTOJik="
                      }

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -89,7 +89,7 @@ DID_DOC_NUMALGO_2_BASE58 = """
                    ],
                    "accept": [
                         "didcomm/v2", "didcomm/aip2;env=rfc587"
-                   ]                   
+                   ]
                }
            ]
        }
@@ -183,7 +183,7 @@ DID_DOC_NUMALGO_2_JWK = """
                    ],
                    "accept": [
                         "didcomm/v2", "didcomm/aip2;env=rfc587"
-                   ]                   
+                   ]
                }
            ]
        }

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -112,7 +112,7 @@ DID_DOC_NUMALGO_2_MULTIBASE = """
            "keyAgreement": [
                {
                    "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
-                   "type": "X25519KeyAgreementKey2019",
+                   "type": "X25519KeyAgreementKey2020",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
                    "publicKeyMultibase": "zJhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr"
                }

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -1,0 +1,228 @@
+PEER_DID_NUMALGO_0 = "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+
+DID_DOC_NUMALGO_O_BASE58 = """
+       {
+           "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+           "authentication": [
+               {
+                   "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                   "type": "Ed25519VerificationKey2018",
+                   "controller": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                   "publicKeyBase58": "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
+               }
+           ]
+       }
+    """
+
+DID_DOC_NUMALGO_O_MULTIBASE = """
+       {
+           "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+           "authentication": [
+               {
+                   "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                   "type": "Ed25519VerificationKey2020",
+                   "controller": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                   "publicKeyMultibase": "zByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
+               }
+           ]
+       }
+    """
+
+DID_DOC_NUMALGO_O_JWK = """
+        {
+            "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+            "authentication": [
+                {
+                    "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                    "type": "JsonWebKey2020",
+                    "controller": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                    "publicKeyJwk": {
+                         "kty": "OKP",                       
+                         "crv": "Ed25519",
+                         "x": "owBhCbktDjkfS6PdQddT0D3yjSitaSysP3YimJ_YgmA="
+                     }
+                }
+            ]
+        }
+    """
+
+PEER_DID_NUMALGO_2 = (
+    "did:peer:2"
+    + ".Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
+    + ".Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+    + ".Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg"
+    + ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0="
+)
+
+DID_DOC_NUMALGO_2_BASE58 = """
+        {
+           "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+           "authentication": [
+               {
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                   "type": "Ed25519VerificationKey2018",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+                   "publicKeyBase58": "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
+               },
+               {
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg",
+                   "type": "Ed25519VerificationKey2018",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+                   "publicKeyBase58": "3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J"
+               }
+           ],
+           "keyAgreement": [
+               {
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+                   "type": "X25519KeyAgreementKey2019",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+                   "publicKeyBase58": "JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr"
+               }
+           ],
+           "service": [
+               {
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#didcommmessaging-0",
+                   "type": "didcommmessaging",
+                   "serviceEndpoint": "https://example.com/endpoint",
+                   "routingKeys": [
+                       "did:example:somemediator#somekey"
+                   ]
+               }
+           ]
+       }
+    """
+
+DID_DOC_NUMALGO_2_MULTIBASE = """
+        {
+           "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+           "authentication": [
+               {
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                   "type": "Ed25519VerificationKey2020",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+                   "publicKeyMultibase": "zByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
+               },
+               {
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg",
+                   "type": "Ed25519VerificationKey2020",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+                   "publicKeyMultibase": "z3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J"
+               }
+           ],
+           "keyAgreement": [
+               {
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+                   "type": "X25519KeyAgreementKey2019",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+                   "publicKeyMultibase": "zJhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr"
+               }
+           ],
+           "service": [
+               {
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#didcommmessaging-0",
+                   "type": "didcommmessaging",
+                   "serviceEndpoint": "https://example.com/endpoint",
+                   "routingKeys": [
+                       "did:example:somemediator#somekey"
+                   ]
+               }
+           ]
+       }
+    """
+
+DID_DOC_NUMALGO_2_JWK = """
+        {
+           "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+           "authentication": [
+               {
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                   "type": "JsonWebKey2020",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+                    "publicKeyJwk": {
+                         "kty": "OKP",                       
+                         "crv": "Ed25519",
+                         "x": "owBhCbktDjkfS6PdQddT0D3yjSitaSysP3YimJ_YgmA="
+                     }
+               },
+               {
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg",
+                   "type": "JsonWebKey2020",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+                    "publicKeyJwk": {
+                         "kty": "OKP",                       
+                         "crv": "Ed25519",
+                         "x": "Itv8B__b1-Jos3LCpUe8EdTFGTCa_Dza6_3848P3R70="
+                     }
+               }
+           ],
+           "keyAgreement": [
+               {
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+                   "type": "JsonWebKey2020",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+                    "publicKeyJwk": {
+                         "kty": "OKP",                       
+                         "crv": "X25519",
+                         "x": "BIiFcQEn3dfvB2pjlhOQQour6jXy9d5s2FKEJNTOJik="
+                     }
+               }
+           ],
+           "service": [
+               {
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#didcommmessaging-0",
+                   "type": "didcommmessaging",
+                   "serviceEndpoint": "https://example.com/endpoint",
+                   "routingKeys": [
+                       "did:example:somemediator#somekey"
+                   ]
+               }
+           ]
+       }
+    """
+
+PEER_DID_NUMALGO_2_2_SERVICES = (
+    "did:peer:2"
+    + ".Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud"
+    + ".Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+    + ".SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0="
+)
+
+DID_DOC_NUMALGO_2_BASE58_2_SERVICES = """
+        {
+            "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=",
+            "authentication": [
+                {
+                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                    "type": "Ed25519VerificationKey2018",
+                    "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=",
+                    "publicKeyBase58": "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
+                }
+            ],
+            "keyAgreement": [
+                {
+                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=#6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud",
+                    "type": "X25519KeyAgreementKey2019",
+                    "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=",
+                    "publicKeyBase58": "DmgBSHMqaZiYqwNMEJJuxWzsGGC8jUYADrfSdBrC6L8s"
+                }
+            ],
+            "service": [
+                {
+                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=#didcommmessaging-0",
+                    "type": "didcommmessaging",
+                    "serviceEndpoint": "https://example.com/endpoint",
+                    "routingKeys": [
+                        "did:example:somemediator#somekey"
+                    ]
+                },
+                {
+                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=#example-1",
+                    "type": "example",
+                    "serviceEndpoint": "https://example.com/endpoint2",
+                    "routingKeys": [
+                        "did:example:somemediator#somekey2"
+                    ]
+                }
+            ]
+        }
+    """

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -51,42 +51,45 @@ PEER_DID_NUMALGO_2 = (
     + ".Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
     + ".Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
     + ".Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg"
-    + ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0="
+    + ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0="
 )
 
 DID_DOC_NUMALGO_2_BASE58 = """
         {
-           "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+           "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=",
            "authentication": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
                    "type": "Ed25519VerificationKey2018",
-                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=",
                    "publicKeyBase58": "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
                },
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=#6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg",
                    "type": "Ed25519VerificationKey2018",
-                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=",
                    "publicKeyBase58": "3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J"
                }
            ],
            "keyAgreement": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=#6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
                    "type": "X25519KeyAgreementKey2019",
-                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=",
                    "publicKeyBase58": "JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr"
                }
            ],
            "service": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#didcommmessaging-0",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=#didcommmessaging-0",
                    "type": "didcommmessaging",
                    "serviceEndpoint": "https://example.com/endpoint",
                    "routingKeys": [
                        "did:example:somemediator#somekey"
-                   ]
+                   ],
+                   "accept": [
+                        "didcomm/v2", "didcomm/aip2;env=rfc587"
+                   ]                   
                }
            ]
        }
@@ -94,36 +97,39 @@ DID_DOC_NUMALGO_2_BASE58 = """
 
 DID_DOC_NUMALGO_2_MULTIBASE = """
         {
-           "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+           "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=",
            "authentication": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
                    "type": "Ed25519VerificationKey2020",
-                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=",
                    "publicKeyMultibase": "zByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
                },
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=#6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg",
                    "type": "Ed25519VerificationKey2020",
-                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=",
                    "publicKeyMultibase": "z3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J"
                }
            ],
            "keyAgreement": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=#6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
                    "type": "X25519KeyAgreementKey2020",
-                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=",
                    "publicKeyMultibase": "zJhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr"
                }
            ],
            "service": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#didcommmessaging-0",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=#didcommmessaging-0",
                    "type": "didcommmessaging",
                    "serviceEndpoint": "https://example.com/endpoint",
                    "routingKeys": [
                        "did:example:somemediator#somekey"
+                   ],
+                   "accept": [
+                        "didcomm/v2", "didcomm/aip2;env=rfc587"
                    ]
                }
            ]
@@ -132,12 +138,12 @@ DID_DOC_NUMALGO_2_MULTIBASE = """
 
 DID_DOC_NUMALGO_2_JWK = """
         {
-           "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+           "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=",
            "authentication": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
                    "type": "JsonWebKey2020",
-                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=",
                     "publicKeyJwk": {
                          "kty": "OKP",
                          "crv": "Ed25519",
@@ -145,9 +151,9 @@ DID_DOC_NUMALGO_2_JWK = """
                      }
                },
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=#6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg",
                    "type": "JsonWebKey2020",
-                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=",
                     "publicKeyJwk": {
                          "kty": "OKP",
                          "crv": "Ed25519",
@@ -157,9 +163,9 @@ DID_DOC_NUMALGO_2_JWK = """
            ],
            "keyAgreement": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=#6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
                    "type": "JsonWebKey2020",
-                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=",
                     "publicKeyJwk": {
                          "kty": "OKP",
                          "crv": "X25519",
@@ -169,12 +175,15 @@ DID_DOC_NUMALGO_2_JWK = """
            ],
            "service": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=#didcommmessaging-0",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=#didcommmessaging-0",
                    "type": "didcommmessaging",
                    "serviceEndpoint": "https://example.com/endpoint",
                    "routingKeys": [
                        "did:example:somemediator#somekey"
-                   ]
+                   ],
+                   "accept": [
+                        "didcomm/v2", "didcomm/aip2;env=rfc587"
+                   ]                   
                }
            ]
        }
@@ -184,31 +193,31 @@ PEER_DID_NUMALGO_2_2_SERVICES = (
     "did:peer:2"
     + ".Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud"
     + ".Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
-    + ".SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0="
+    + ".SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0="
 )
 
 DID_DOC_NUMALGO_2_BASE58_2_SERVICES = """
         {
-            "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=",
+            "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0=",
             "authentication": [
                 {
-                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0=#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
                     "type": "Ed25519VerificationKey2020",
-                    "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=",
+                    "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0=",
                     "publicKeyMultibase": "zByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
                 }
             ],
             "keyAgreement": [
                 {
-                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=#6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud",
+                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0=#6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud",
                     "type": "X25519KeyAgreementKey2020",
-                    "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=",
+                    "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0=",
                     "publicKeyMultibase": "zDmgBSHMqaZiYqwNMEJJuxWzsGGC8jUYADrfSdBrC6L8s"
                 }
             ],
             "service": [
                 {
-                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=#didcommmessaging-0",
+                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0=#didcommmessaging-0",
                     "type": "didcommmessaging",
                     "serviceEndpoint": "https://example.com/endpoint",
                     "routingKeys": [
@@ -216,12 +225,13 @@ DID_DOC_NUMALGO_2_BASE58_2_SERVICES = """
                     ]
                 },
                 {
-                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=#example-1",
+                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0=#example-1",
                     "type": "example",
                     "serviceEndpoint": "https://example.com/endpoint2",
                     "routingKeys": [
                         "did:example:somemediator#somekey2"
-                    ]
+                    ],
+                    "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
                 }
             ]
         }

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -193,17 +193,17 @@ DID_DOC_NUMALGO_2_BASE58_2_SERVICES = """
             "authentication": [
                 {
                     "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
-                    "type": "Ed25519VerificationKey2018",
+                    "type": "Ed25519VerificationKey2020",
                     "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=",
-                    "publicKeyBase58": "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
+                    "publicKeyMultibase": "zByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
                 }
             ],
             "keyAgreement": [
                 {
                     "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=#6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud",
-                    "type": "X25519KeyAgreementKey2019",
+                    "type": "X25519KeyAgreementKey2020",
                     "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfV0=",
-                    "publicKeyBase58": "DmgBSHMqaZiYqwNMEJJuxWzsGGC8jUYADrfSdBrC6L8s"
+                    "publicKeyMultibase": "zDmgBSHMqaZiYqwNMEJJuxWzsGGC8jUYADrfSdBrC6L8s"
                 }
             ],
             "service": [


### PR DESCRIPTION
- fixed numalgo0 authentication field in the resolved DID DOC (must be one-element list)
- fixed service decoding
- fixed type field in verification methods of the resolved DID Doc to match the DID spec
- supported various formats of verification materials when resolving: base58 (default for now), JWK, multibase
- support "accept" field in services
- fix DIDCommMessaging service name (it was in lower case)
- refactorings, improvements, more tests
- added Assumptions and Limitations to README