### PR TITLE
Fix: missing didpeer.core in wheel

### DIFF
--- a/peerdid/__init__.py
+++ b/peerdid/__init__.py
@@ -4,6 +4,6 @@ from . import core, dids, errors, keys
 
 from pydid import DID, DIDDocument
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 __all__ = ["__version__", "core", "errors", "dids", "keys", "DID", "DIDDocument"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ classifiers =
     # Topic ::
 
 [options]
-packages = peerdid
+packages = peerdid,peerdid.core
 include_package_data = true
 python_requires = >= 3.7
 # Dependencies are in setup.py for GitHub's dependency graph.


### PR DESCRIPTION
Fix `setup.cfg` to include `didpeer.core` in wheel.

Fixes #43.