### PR TITLE
DEFAULT_CONTEXT does not exist

### DIFF
--- a/peerdid/dids.py
+++ b/peerdid/dids.py
@@ -126,7 +126,7 @@ def resolve_peer_did(
 def _did_document_builder(peer_did: Union[str, DID]) -> DIDDocumentBuilder:
     try:
         return DIDDocumentBuilder(
-            peer_did, context=DIDDocumentBuilder.__default_context()
+            peer_did
         )
     except InvalidDIDError as e:
         raise MalformedPeerDIDError("Invalid peer DID") from e

--- a/peerdid/dids.py
+++ b/peerdid/dids.py
@@ -125,9 +125,7 @@ def resolve_peer_did(
 
 def _did_document_builder(peer_did: Union[str, DID]) -> DIDDocumentBuilder:
     try:
-        return DIDDocumentBuilder(
-            peer_did
-        )
+        return DIDDocumentBuilder(peer_did)
     except InvalidDIDError as e:
         raise MalformedPeerDIDError("Invalid peer DID") from e
 

--- a/peerdid/dids.py
+++ b/peerdid/dids.py
@@ -126,7 +126,7 @@ def resolve_peer_did(
 def _did_document_builder(peer_did: Union[str, DID]) -> DIDDocumentBuilder:
     try:
         return DIDDocumentBuilder(
-            peer_did, context=DIDDocumentBuilder.DEFAULT_CONTEXT.copy()
+            peer_did, context=DIDDocumentBuilder.__default_context()
         )
     except InvalidDIDError as e:
         raise MalformedPeerDIDError("Invalid peer DID") from e


### PR DESCRIPTION
This may have been changed in the pydid library, but the resolve_peer_did() method throws an error because DIDDocumentBuilder.DEFAULT_CONTEXT does not exist. 

https://github.com/Indicio-tech/pydid/blob/59ffe7406729db2e9f31eac0fdf011c21b4a1c7a/pydid/doc/builder.py#L182C40-L182C57

Updating to match new class attribute. 