### PR TITLE
Add peer did 3 convert method

### DIFF
--- a/peerdid/dids.py
+++ b/peerdid/dids.py
@@ -1,11 +1,10 @@
 """Peer DID document generation and resolution."""
 
 import re
-
+from hashlib import sha256
 from typing import Optional, Sequence, Union
 
 from pydid import DID, DIDDocument, DIDDocumentBuilder, DIDUrl, InvalidDIDError
-
 from .core.peer_did_helper import (
     Numalgo2Prefix,
     ServiceJson,
@@ -14,7 +13,8 @@ from .core.peer_did_helper import (
     decode_service,
 )
 from .errors import MalformedPeerDIDError
-from .keys import KeyFormat, KeyRelationshipType, BaseKey
+
+from .keys import KeyFormat, KeyRelationshipType, BaseKey, to_multibase, MultibaseFormat
 
 PEER_DID_PATTERN = re.compile(
     r"^did:peer:(([0](z)([1-9a-km-zA-HJ-NP-Z]+))|(2((\.[AEVID](z)([1-9a-km-zA-HJ-NP-Z]+))+"
@@ -187,3 +187,12 @@ def _build_did_doc_numalgo_2(
             raise MalformedPeerDIDError("Unknown prefix: {}.".format(prefix))
 
     return builder.build()
+
+
+
+def gen_did_peer_3(peer_did_2 : Union[str,DID]) -> DID:
+    if not peer_did_2.startswith("did:peer:2"):
+        raise MalformedPeerDIDError("did:peer:2 expected")
+    
+    content = to_multibase(sha256(peer_did_2.lstrip("did:peer:2")),MultibaseFormat.BASE58)
+    return "did:peer:3"+content

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,6 @@ from setuptools import setup
 
 # TODO move remaining things
 setup(
-    install_requires=["base58~=2.1.0", "pydid=0.4.0a0", "varint~=1.0.2"],
+    install_requires=["base58~=2.1.0", "pydid~==0.4.0a0", "varint~=1.0.2"],
     extras_require={"tests": ["pytest==6.2.5", "pytest-xdist==2.3.0"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,6 @@ from setuptools import setup
 
 # TODO move remaining things
 setup(
-    install_requires=["base58~=2.1.0", "pydid~=0.3.8", "varint~=1.0.2"],
+    install_requires=["base58~=2.1.0", "pydid~=0.4", "varint~=1.0.2"],
     extras_require={"tests": ["pytest==6.2.5", "pytest-xdist==2.3.0"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,6 @@ from setuptools import setup
 
 # TODO move remaining things
 setup(
-    install_requires=["base58~=2.1.0", "pydid~=0.4", "varint~=1.0.2"],
+    install_requires=["base58~=2.1.0", "pydid=0.4.0a0", "varint~=1.0.2"],
     extras_require={"tests": ["pytest==6.2.5", "pytest-xdist==2.3.0"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,6 @@ from setuptools import setup
 
 # TODO move remaining things
 setup(
-    install_requires=["base58~=2.1.0", "pydid~==0.4.0a0", "varint~=1.0.2"],
+    install_requires=["base58~=2.1.0", "pydid~=0.4.0a0", "varint~=1.0.2"],
     extras_require={"tests": ["pytest==6.2.5", "pytest-xdist==2.3.0"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,6 @@ from setuptools import setup
 
 # TODO move remaining things
 setup(
-    install_requires=["base58~=2.1.0", "pydid", "varint~=1.0.2"],
+    install_requires=["base58~=2.1.0", "pydid~=0.3.8", "varint~=1.0.2"],
     extras_require={"tests": ["pytest==6.2.5", "pytest-xdist==2.3.0"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,6 @@ from setuptools import setup
 
 # TODO move remaining things
 setup(
-    install_requires=["base58~=2.1.0", "pydid~=0.3.8", "varint~=1.0.2"],
+    install_requires=["base58~=2.1.0", "pydid~=0.3.9a0", "varint~=1.0.2"],
     extras_require={"tests": ["pytest==6.2.5", "pytest-xdist==2.3.0"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,6 @@ from setuptools import setup
 
 # TODO move remaining things
 setup(
-    install_requires=["base58~=2.1.0", "pydid~=0.3.5", "varint~=1.0.2"],
+    install_requires=["base58~=2.1.0", "pydid~=0.3.8", "varint~=1.0.2"],
     extras_require={"tests": ["pytest==6.2.5", "pytest-xdist==2.3.0"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,6 @@ from setuptools import setup
 
 # TODO move remaining things
 setup(
-    install_requires=["base58~=2.1.0", "pydid~=0.4.0a0", "varint~=1.0.2"],
+    install_requires=["base58~=2.1.0", "pydid", "varint~=1.0.2"],
     extras_require={"tests": ["pytest==6.2.5", "pytest-xdist==2.3.0"]},
 )


### PR DESCRIPTION
`did:peer:3` is dervied from the `did:peer:2` as defined here. 

https://identity.foundation/peer-did-method-spec/#example-5-abnf-for-peer-dids

Added a method to match. 