### PR TITLE
chore: update pydid and drop python 3.7

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.9
 
       - name: Install black
         run: pip install black
@@ -77,7 +77,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.9
 
       - name: Install flake8
         run: pip install flake8
@@ -88,14 +88,13 @@ jobs:
   unit:
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
         os: [ ubuntu-latest, windows-latest, macos-latest ]
         include:
           - {python-version: '3.11', toxenv: py311}
           - {python-version: '3.10', toxenv: py310}
           - {python-version: '3.9', toxenv: py39}
           - {python-version: '3.8', toxenv: py38}
-          - {python-version: '3.7', toxenv: py37}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ classifiers =
 [options]
 packages = peerdid,peerdid.core
 include_package_data = true
-python_requires = >= 3.7
+python_requires = >= 3.8
 # Dependencies are in setup.py for GitHub's dependency graph.
 
 [options.packages.find]

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,6 @@ from setuptools import setup
 
 # TODO move remaining things
 setup(
-    install_requires=["base58~=2.1.0", "pydid~=0.3.5", "varint~=1.0.2"],
+    install_requires=["base58~=2.1.0", "pydid~=0.4.0.post1", "varint~=1.0.2"],
     extras_require={"tests": ["pytest==6.2.5", "pytest-xdist==2.3.0"]},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{311,310,39,38,37,36}
+    py{311,310,39,38}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
This PR updates the PyDID dependency to the latest version and also drops support for Python 3.7. Python 3.7 has reached EOL.